### PR TITLE
Add load_clvm function for development purposes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,6 +668,7 @@ dependencies = [
  "chia-sha2 0.22.0",
  "clvm-traits",
  "clvm-utils",
+ "clvm_tools_rs",
  "clvmr",
  "hex",
  "hex-literal",
@@ -675,6 +676,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rstest",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/crates/chia-sdk-driver/src/layers/streaming_layer.rs
+++ b/crates/chia-sdk-driver/src/layers/streaming_layer.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_protocol::Bytes32;
 use chia_sdk_types::Mod;
 use clvm_traits::{FromClvm, ToClvm};
@@ -193,6 +195,11 @@ pub struct StreamPuzzleSolution {
 }
 
 impl Mod for StreamPuzzle1stCurryArgs {
-    const MOD_REVEAL: &[u8] = &STREAM_PUZZLE;
-    const MOD_HASH: TreeHash = STREAM_PUZZLE_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&STREAM_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        STREAM_PUZZLE_HASH
+    }
 }

--- a/crates/chia-sdk-driver/src/spend_context.rs
+++ b/crates/chia-sdk-driver/src/spend_context.rs
@@ -109,7 +109,7 @@ impl SpendContext {
     where
         T: Mod,
     {
-        self.puzzle(T::MOD_HASH, T::MOD_REVEAL)
+        self.puzzle(T::mod_hash(), T::mod_reveal().as_ref())
     }
 
     pub fn curry<T>(&mut self, args: T) -> Result<NodePtr, DriverError>

--- a/crates/chia-sdk-types/Cargo.toml
+++ b/crates/chia-sdk-types/Cargo.toml
@@ -31,6 +31,8 @@ clvm-utils = { workspace = true }
 clvmr = { workspace = true }
 hex-literal = { workspace = true }
 once_cell = { workspace = true }
+thiserror = { workspace = true }
+clvm_tools_rs = { workspace = true }
 
 [dev-dependencies]
 hex = { workspace = true }

--- a/crates/chia-sdk-types/load_clvm_test.clsp
+++ b/crates/chia-sdk-types/load_clvm_test.clsp
@@ -1,0 +1,3 @@
+(mod (AAA BBB)
+    (+ (* AAA BBB) AAA BBB)
+)

--- a/crates/chia-sdk-types/src/lib.rs
+++ b/crates/chia-sdk-types/src/lib.rs
@@ -2,12 +2,14 @@ pub mod puzzles;
 
 mod condition;
 mod constants;
+mod load_clvm;
 mod merkle_tree;
 mod puzzle_mod;
 mod run_puzzle;
 
 pub use condition::*;
 pub use constants::*;
+pub use load_clvm::*;
 pub use merkle_tree::*;
 pub use puzzle_mod::*;
 pub use run_puzzle::*;

--- a/crates/chia-sdk-types/src/load_clvm.rs
+++ b/crates/chia-sdk-types/src/load_clvm.rs
@@ -1,0 +1,121 @@
+use std::{collections::HashMap, fs, io, path::Path, rc::Rc};
+
+use clvm_tools_rs::{
+    classic::clvm_tools::clvmc::compile_clvm_text,
+    compiler::{compiler::DefaultCompilerOpts, comptypes::CompilerOpts},
+};
+use clvm_utils::{tree_hash, TreeHash};
+use clvmr::{serde::node_to_bytes, Allocator};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum LoadClvmError {
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+
+    #[error("Invalid file name")]
+    InvalidFileName,
+
+    #[error("Compiler error: {0}")]
+    Compiler(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Compilation {
+    pub reveal: Vec<u8>,
+    pub hash: TreeHash,
+}
+
+pub fn load_clvm<P: AsRef<Path>>(
+    path: P,
+    include_paths: &[String],
+) -> Result<Compilation, LoadClvmError> {
+    let path = path.as_ref();
+
+    let mut allocator = Allocator::new();
+
+    let opts = Rc::new(DefaultCompilerOpts::new(
+        path.file_name()
+            .ok_or(LoadClvmError::InvalidFileName)?
+            .to_str()
+            .ok_or(LoadClvmError::InvalidFileName)?,
+    ))
+    .set_search_paths(include_paths);
+
+    let text = fs::read_to_string(path)?;
+
+    let ptr = compile_clvm_text(
+        &mut allocator,
+        opts,
+        &mut HashMap::new(),
+        &text,
+        path.to_str().ok_or(LoadClvmError::InvalidFileName)?,
+        false,
+    )
+    .map_err(|error| LoadClvmError::Compiler(format!("{error:?}")))?;
+
+    let hash = tree_hash(&allocator, ptr);
+    let reveal = node_to_bytes(&allocator, ptr)?;
+
+    Ok(Compilation { reveal, hash })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use clvm_traits::{FromClvm, ToClvm};
+    use clvm_utils::CurriedProgram;
+    use clvmr::{serde::node_from_bytes, NodePtr};
+    use once_cell::sync::Lazy;
+
+    use crate::{run_puzzle, Mod};
+
+    use super::*;
+
+    #[test]
+    fn test_load_clvm() -> anyhow::Result<()> {
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, ToClvm, FromClvm)]
+        #[clvm(curry)]
+        struct TestArgs {
+            a: u64,
+            b: u64,
+        }
+
+        static TEST_MOD: Lazy<Compilation> = Lazy::new(|| {
+            load_clvm(
+                "load_clvm_test.clsp",
+                &[".".to_string(), "include".to_string()],
+            )
+            .unwrap()
+        });
+
+        impl Mod for TestArgs {
+            fn mod_reveal() -> Cow<'static, [u8]> {
+                Cow::Owned(TEST_MOD.reveal.clone())
+            }
+
+            fn mod_hash() -> TreeHash {
+                TEST_MOD.hash
+            }
+        }
+
+        let args = TestArgs { a: 10, b: 20 };
+
+        let mut allocator = Allocator::new();
+
+        let mod_ptr = node_from_bytes(&mut allocator, TestArgs::mod_reveal().as_ref())?;
+
+        let ptr = CurriedProgram {
+            program: mod_ptr,
+            args,
+        }
+        .to_clvm(&mut allocator)?;
+
+        let output = run_puzzle(&mut allocator, ptr, NodePtr::NIL)?;
+
+        assert_eq!(hex::encode(node_to_bytes(&allocator, output)?), "8200e6");
+
+        Ok(())
+    }
+}

--- a/crates/chia-sdk-types/src/puzzle_mod.rs
+++ b/crates/chia-sdk-types/src/puzzle_mod.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_puzzle_types::{
     cat::{CatArgs, EverythingWithSignatureTailArgs, GenesisByCoinIdTailArgs},
     did::DidArgs,
@@ -44,8 +46,8 @@ use clvm_utils::{CurriedProgram, TreeHash, TreeHasher};
 /// let puzzle_hash = args.curry_tree_hash();
 /// ```
 pub trait Mod {
-    const MOD_REVEAL: &[u8];
-    const MOD_HASH: TreeHash;
+    fn mod_reveal() -> Cow<'static, [u8]>;
+    fn mod_hash() -> TreeHash;
 
     /// Curry the arguments into the [`MOD_HASH`](Mod::MOD_HASH).
     fn curry_tree_hash(&self) -> TreeHash
@@ -53,7 +55,7 @@ pub trait Mod {
         Self: Sized + ToClvm<TreeHasher>,
     {
         CurriedProgram {
-            program: Self::MOD_HASH,
+            program: Self::mod_hash(),
             args: self,
         }
         .to_clvm(&mut TreeHasher)
@@ -65,57 +67,111 @@ impl<T> Mod for &T
 where
     T: Mod,
 {
-    const MOD_REVEAL: &'static [u8] = T::MOD_REVEAL;
-    const MOD_HASH: TreeHash = T::MOD_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        T::mod_reveal()
+    }
+
+    fn mod_hash() -> TreeHash {
+        T::mod_hash()
+    }
 }
 
 impl Mod for StandardArgs {
-    const MOD_REVEAL: &[u8] = &P2_DELEGATED_PUZZLE_OR_HIDDEN_PUZZLE;
-    const MOD_HASH: TreeHash = TreeHash::new(P2_DELEGATED_PUZZLE_OR_HIDDEN_PUZZLE_HASH);
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&P2_DELEGATED_PUZZLE_OR_HIDDEN_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        TreeHash::new(P2_DELEGATED_PUZZLE_OR_HIDDEN_PUZZLE_HASH)
+    }
 }
 
 impl<I> Mod for CatArgs<I> {
-    const MOD_REVEAL: &[u8] = &CAT_PUZZLE;
-    const MOD_HASH: TreeHash = TreeHash::new(CAT_PUZZLE_HASH);
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&CAT_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        TreeHash::new(CAT_PUZZLE_HASH)
+    }
 }
 
 impl<I, M> Mod for DidArgs<I, M> {
-    const MOD_REVEAL: &[u8] = &DID_INNERPUZ;
-    const MOD_HASH: TreeHash = TreeHash::new(DID_INNERPUZ_HASH);
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&DID_INNERPUZ)
+    }
+
+    fn mod_hash() -> TreeHash {
+        TreeHash::new(DID_INNERPUZ_HASH)
+    }
 }
 
 impl Mod for NftIntermediateLauncherArgs {
-    const MOD_REVEAL: &[u8] = &NFT_INTERMEDIATE_LAUNCHER;
-    const MOD_HASH: TreeHash = TreeHash::new(NFT_INTERMEDIATE_LAUNCHER_HASH);
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&NFT_INTERMEDIATE_LAUNCHER)
+    }
+
+    fn mod_hash() -> TreeHash {
+        TreeHash::new(NFT_INTERMEDIATE_LAUNCHER_HASH)
+    }
 }
 
 impl Mod for NftRoyaltyTransferPuzzleArgs {
-    const MOD_REVEAL: &[u8] = &NFT_OWNERSHIP_TRANSFER_PROGRAM_ONE_WAY_CLAIM_WITH_ROYALTIES;
-    const MOD_HASH: TreeHash =
-        TreeHash::new(NFT_OWNERSHIP_TRANSFER_PROGRAM_ONE_WAY_CLAIM_WITH_ROYALTIES_HASH);
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&NFT_OWNERSHIP_TRANSFER_PROGRAM_ONE_WAY_CLAIM_WITH_ROYALTIES)
+    }
+
+    fn mod_hash() -> TreeHash {
+        TreeHash::new(NFT_OWNERSHIP_TRANSFER_PROGRAM_ONE_WAY_CLAIM_WITH_ROYALTIES_HASH)
+    }
 }
 
 impl<I, P> Mod for NftOwnershipLayerArgs<I, P> {
-    const MOD_REVEAL: &[u8] = &NFT_OWNERSHIP_LAYER;
-    const MOD_HASH: TreeHash = TreeHash::new(NFT_OWNERSHIP_LAYER_HASH);
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&NFT_OWNERSHIP_LAYER)
+    }
+
+    fn mod_hash() -> TreeHash {
+        TreeHash::new(NFT_OWNERSHIP_LAYER_HASH)
+    }
 }
 
 impl<I, M> Mod for NftStateLayerArgs<I, M> {
-    const MOD_REVEAL: &[u8] = &NFT_STATE_LAYER;
-    const MOD_HASH: TreeHash = TreeHash::new(NFT_STATE_LAYER_HASH);
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&NFT_STATE_LAYER)
+    }
+
+    fn mod_hash() -> TreeHash {
+        TreeHash::new(NFT_STATE_LAYER_HASH)
+    }
 }
 
 impl<I> Mod for SingletonArgs<I> {
-    const MOD_REVEAL: &[u8] = &SINGLETON_TOP_LAYER_V1_1;
-    const MOD_HASH: TreeHash = TreeHash::new(SINGLETON_TOP_LAYER_V1_1_HASH);
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&SINGLETON_TOP_LAYER_V1_1)
+    }
+
+    fn mod_hash() -> TreeHash {
+        TreeHash::new(SINGLETON_TOP_LAYER_V1_1_HASH)
+    }
 }
 
 impl Mod for EverythingWithSignatureTailArgs {
-    const MOD_REVEAL: &[u8] = &EVERYTHING_WITH_SIGNATURE;
-    const MOD_HASH: TreeHash = TreeHash::new(EVERYTHING_WITH_SIGNATURE_HASH);
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&EVERYTHING_WITH_SIGNATURE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        TreeHash::new(EVERYTHING_WITH_SIGNATURE_HASH)
+    }
 }
 
 impl Mod for GenesisByCoinIdTailArgs {
-    const MOD_REVEAL: &[u8] = &GENESIS_BY_COIN_ID;
-    const MOD_HASH: TreeHash = TreeHash::new(GENESIS_BY_COIN_ID_HASH);
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&GENESIS_BY_COIN_ID)
+    }
+
+    fn mod_hash() -> TreeHash {
+        TreeHash::new(GENESIS_BY_COIN_ID_HASH)
+    }
 }

--- a/crates/chia-sdk-types/src/puzzles/augmented_condition.rs
+++ b/crates/chia-sdk-types/src/puzzles/augmented_condition.rs
@@ -1,4 +1,7 @@
 use chia_puzzles::{AUGMENTED_CONDITION, AUGMENTED_CONDITION_HASH};
+
+use std::borrow::Cow;
+
 use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::TreeHash;
 
@@ -21,8 +24,13 @@ impl<T, I> AugmentedConditionArgs<T, I> {
 }
 
 impl<T, I> Mod for AugmentedConditionArgs<T, I> {
-    const MOD_REVEAL: &[u8] = &AUGMENTED_CONDITION;
-    const MOD_HASH: TreeHash = TreeHash::new(AUGMENTED_CONDITION_HASH);
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&AUGMENTED_CONDITION_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        AUGMENTED_CONDITION_PUZZLE_HASH
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]

--- a/crates/chia-sdk-types/src/puzzles/augmented_condition.rs
+++ b/crates/chia-sdk-types/src/puzzles/augmented_condition.rs
@@ -25,11 +25,11 @@ impl<T, I> AugmentedConditionArgs<T, I> {
 
 impl<T, I> Mod for AugmentedConditionArgs<T, I> {
     fn mod_reveal() -> Cow<'static, [u8]> {
-        Cow::Borrowed(&AUGMENTED_CONDITION_PUZZLE)
+        Cow::Borrowed(&AUGMENTED_CONDITION)
     }
 
     fn mod_hash() -> TreeHash {
-        AUGMENTED_CONDITION_PUZZLE_HASH
+        AUGMENTED_CONDITION_HASH.into()
     }
 }
 

--- a/crates/chia-sdk-types/src/puzzles/datalayer/delegation_layer.rs
+++ b/crates/chia-sdk-types/src/puzzles/datalayer/delegation_layer.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_protocol::Bytes32;
 use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::{CurriedProgram, ToTreeHash, TreeHash};
@@ -90,6 +92,11 @@ pub struct DelegationLayerSolution<P, S> {
 }
 
 impl Mod for DelegationLayerArgs {
-    const MOD_REVEAL: &[u8] = &DELEGATION_LAYER_PUZZLE;
-    const MOD_HASH: TreeHash = DELEGATION_LAYER_PUZZLE_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&DELEGATION_LAYER_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        DELEGATION_LAYER_PUZZLE_HASH
+    }
 }

--- a/crates/chia-sdk-types/src/puzzles/datalayer/writer_filter.rs
+++ b/crates/chia-sdk-types/src/puzzles/datalayer/writer_filter.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::{CurriedProgram, ToTreeHash, TreeHash};
 use hex_literal::hex;
@@ -47,6 +49,11 @@ pub struct WriterLayerSolution<I> {
 }
 
 impl<I> Mod for WriterLayerArgs<I> {
-    const MOD_REVEAL: &[u8] = &WRITER_LAYER_PUZZLE;
-    const MOD_HASH: TreeHash = WRITER_LAYER_PUZZLE_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&WRITER_LAYER_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        WRITER_LAYER_PUZZLE_HASH
+    }
 }

--- a/crates/chia-sdk-types/src/puzzles/mips/add_delegated_puzzle_wrapper.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/add_delegated_puzzle_wrapper.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::TreeHash;
 use hex_literal::hex;
@@ -21,8 +23,13 @@ impl<W, P> AddDelegatedPuzzleWrapper<W, P> {
 }
 
 impl<W, P> Mod for AddDelegatedPuzzleWrapper<W, P> {
-    const MOD_REVEAL: &[u8] = &ADD_DELEGATED_PUZZLE_WRAPPER_PUZZLE;
-    const MOD_HASH: TreeHash = ADD_DELEGATED_PUZZLE_WRAPPER_PUZZLE_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&ADD_DELEGATED_PUZZLE_WRAPPER_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        ADD_DELEGATED_PUZZLE_WRAPPER_PUZZLE_HASH
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]

--- a/crates/chia-sdk-types/src/puzzles/mips/delegated_feeder.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/delegated_feeder.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::TreeHash;
 use hex_literal::hex;
@@ -17,8 +19,13 @@ impl<I> DelegatedFeederArgs<I> {
 }
 
 impl<I> Mod for DelegatedFeederArgs<I> {
-    const MOD_REVEAL: &[u8] = &DELEGATED_FEEDER_PUZZLE;
-    const MOD_HASH: TreeHash = DELEGATED_FEEDER_PUZZLE_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&DELEGATED_FEEDER_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        DELEGATED_FEEDER_PUZZLE_HASH
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]

--- a/crates/chia-sdk-types/src/puzzles/mips/enforce_delegated_puzzle_wrappers.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/enforce_delegated_puzzle_wrappers.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_protocol::Bytes32;
 use clvm_traits::{clvm_quote, FromClvm, ToClvm};
 use clvm_utils::{ToTreeHash, TreeHash};
@@ -29,8 +31,13 @@ impl EnforceDelegatedPuzzleWrappers {
 }
 
 impl Mod for EnforceDelegatedPuzzleWrappers {
-    const MOD_REVEAL: &[u8] = &ENFORCE_DELEGATED_PUZZLE_WRAPPERS_PUZZLE;
-    const MOD_HASH: TreeHash = ENFORCE_DELEGATED_PUZZLE_WRAPPERS_PUZZLE_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&ENFORCE_DELEGATED_PUZZLE_WRAPPERS_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        ENFORCE_DELEGATED_PUZZLE_WRAPPERS_PUZZLE_HASH
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]

--- a/crates/chia-sdk-types/src/puzzles/mips/index_wrapper.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/index_wrapper.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::TreeHash;
 use hex_literal::hex;
@@ -21,8 +23,13 @@ impl<I> IndexWrapperArgs<I> {
 }
 
 impl<I> Mod for IndexWrapperArgs<I> {
-    const MOD_REVEAL: &[u8] = &INDEX_WRAPPER;
-    const MOD_HASH: TreeHash = INDEX_WRAPPER_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&INDEX_WRAPPER)
+    }
+
+    fn mod_hash() -> TreeHash {
+        INDEX_WRAPPER_HASH
+    }
 }
 
 pub const INDEX_WRAPPER: [u8; 7] = hex!("ff02ff05ff0780");

--- a/crates/chia-sdk-types/src/puzzles/mips/m_of_n.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/m_of_n.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_protocol::Bytes32;
 use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::TreeHash;
@@ -22,8 +24,13 @@ impl MofNArgs {
 }
 
 impl Mod for MofNArgs {
-    const MOD_REVEAL: &[u8] = &M_OF_N_PUZZLE;
-    const MOD_HASH: TreeHash = M_OF_N_PUZZLE_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&M_OF_N_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        M_OF_N_PUZZLE_HASH
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]

--- a/crates/chia-sdk-types/src/puzzles/mips/members/bls_member.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/members/bls_member.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_bls::PublicKey;
 use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::TreeHash;
@@ -18,8 +20,13 @@ impl BlsMember {
 }
 
 impl Mod for BlsMember {
-    const MOD_REVEAL: &[u8] = &BLS_MEMBER;
-    const MOD_HASH: TreeHash = BLS_MEMBER_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&BLS_MEMBER)
+    }
+
+    fn mod_hash() -> TreeHash {
+        BLS_MEMBER_HASH
+    }
 }
 
 pub const BLS_MEMBER: [u8; 41] = hex!(

--- a/crates/chia-sdk-types/src/puzzles/mips/members/bls_taproot_member.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/members/bls_taproot_member.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_bls::PublicKey;
 use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::TreeHash;
@@ -18,8 +20,13 @@ impl BlsTaprootMember {
 }
 
 impl Mod for BlsTaprootMember {
-    const MOD_REVEAL: &[u8] = &BLS_TAPROOT_MEMBER;
-    const MOD_HASH: TreeHash = BLS_TAPROOT_MEMBER_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&BLS_TAPROOT_MEMBER)
+    }
+
+    fn mod_hash() -> TreeHash {
+        BLS_TAPROOT_MEMBER_HASH
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]

--- a/crates/chia-sdk-types/src/puzzles/mips/members/fixed_puzzle_member.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/members/fixed_puzzle_member.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_protocol::Bytes32;
 use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::TreeHash;
@@ -18,8 +20,13 @@ impl FixedPuzzleMember {
 }
 
 impl Mod for FixedPuzzleMember {
-    const MOD_REVEAL: &[u8] = &FIXED_PUZZLE_MEMBER;
-    const MOD_HASH: TreeHash = FIXED_PUZZLE_MEMBER_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&FIXED_PUZZLE_MEMBER)
+    }
+
+    fn mod_hash() -> TreeHash {
+        FIXED_PUZZLE_MEMBER_HASH
+    }
 }
 
 pub const FIXED_PUZZLE_MEMBER: [u8; 25] =

--- a/crates/chia-sdk-types/src/puzzles/mips/members/passkey_member.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/members/passkey_member.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_protocol::{Bytes, Bytes32};
 use chia_secp::{R1PublicKey, R1Signature};
 use clvm_traits::{FromClvm, ToClvm};
@@ -19,8 +21,13 @@ impl PasskeyMember {
 }
 
 impl Mod for PasskeyMember {
-    const MOD_REVEAL: &[u8] = &PASSKEY_MEMBER;
-    const MOD_HASH: TreeHash = PASSKEY_MEMBER_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&PASSKEY_MEMBER)
+    }
+
+    fn mod_hash() -> TreeHash {
+        PASSKEY_MEMBER_HASH
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]

--- a/crates/chia-sdk-types/src/puzzles/mips/members/passkey_member_puzzle_assert.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/members/passkey_member_puzzle_assert.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_protocol::{Bytes, Bytes32};
 use chia_secp::{R1PublicKey, R1Signature};
 use clvm_traits::{FromClvm, ToClvm};
@@ -19,8 +21,13 @@ impl PasskeyMemberPuzzleAssert {
 }
 
 impl Mod for PasskeyMemberPuzzleAssert {
-    const MOD_REVEAL: &[u8] = &PASSKEY_MEMBER_PUZZLE_ASSERT;
-    const MOD_HASH: TreeHash = PASSKEY_MEMBER_PUZZLE_ASSERT_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&PASSKEY_MEMBER_PUZZLE_ASSERT)
+    }
+
+    fn mod_hash() -> TreeHash {
+        PASSKEY_MEMBER_PUZZLE_ASSERT_HASH
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]

--- a/crates/chia-sdk-types/src/puzzles/mips/members/secp256k1_member.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/members/secp256k1_member.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_protocol::Bytes32;
 use chia_secp::{K1PublicKey, K1Signature};
 use clvm_traits::{FromClvm, ToClvm};
@@ -19,8 +21,13 @@ impl Secp256k1Member {
 }
 
 impl Mod for Secp256k1Member {
-    const MOD_REVEAL: &[u8] = &SECP256K1_MEMBER;
-    const MOD_HASH: TreeHash = SECP256K1_MEMBER_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&SECP256K1_MEMBER)
+    }
+
+    fn mod_hash() -> TreeHash {
+        SECP256K1_MEMBER_HASH
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]

--- a/crates/chia-sdk-types/src/puzzles/mips/members/secp256k1_member_puzzle_assert.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/members/secp256k1_member_puzzle_assert.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_protocol::Bytes32;
 use chia_secp::{K1PublicKey, K1Signature};
 use clvm_traits::{FromClvm, ToClvm};
@@ -19,8 +21,13 @@ impl Secp256k1MemberPuzzleAssert {
 }
 
 impl Mod for Secp256k1MemberPuzzleAssert {
-    const MOD_REVEAL: &[u8] = &SECP256K1_MEMBER_PUZZLE_ASSERT;
-    const MOD_HASH: TreeHash = SECP256K1_MEMBER_PUZZLE_ASSERT_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&SECP256K1_MEMBER_PUZZLE_ASSERT)
+    }
+
+    fn mod_hash() -> TreeHash {
+        SECP256K1_MEMBER_PUZZLE_ASSERT_HASH
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]

--- a/crates/chia-sdk-types/src/puzzles/mips/members/secp256r1_member.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/members/secp256r1_member.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_protocol::Bytes32;
 use chia_secp::{R1PublicKey, R1Signature};
 use clvm_traits::{FromClvm, ToClvm};
@@ -19,8 +21,13 @@ impl Secp256r1Member {
 }
 
 impl Mod for Secp256r1Member {
-    const MOD_REVEAL: &[u8] = &SECP256R1_MEMBER;
-    const MOD_HASH: TreeHash = SECP256R1_MEMBER_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&SECP256R1_MEMBER)
+    }
+
+    fn mod_hash() -> TreeHash {
+        SECP256R1_MEMBER_HASH
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]

--- a/crates/chia-sdk-types/src/puzzles/mips/members/secp256r1_member_puzzle_assert.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/members/secp256r1_member_puzzle_assert.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_protocol::Bytes32;
 use chia_secp::{R1PublicKey, R1Signature};
 use clvm_traits::{FromClvm, ToClvm};
@@ -19,8 +21,13 @@ impl Secp256r1MemberPuzzleAssert {
 }
 
 impl Mod for Secp256r1MemberPuzzleAssert {
-    const MOD_REVEAL: &[u8] = &SECP256R1_MEMBER_PUZZLE_ASSERT;
-    const MOD_HASH: TreeHash = SECP256R1_MEMBER_PUZZLE_ASSERT_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&SECP256R1_MEMBER_PUZZLE_ASSERT)
+    }
+
+    fn mod_hash() -> TreeHash {
+        SECP256R1_MEMBER_PUZZLE_ASSERT_HASH
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]

--- a/crates/chia-sdk-types/src/puzzles/mips/members/singleton_member.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/members/singleton_member.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_protocol::Bytes32;
 use chia_puzzle_types::singleton::SingletonStruct;
 use clvm_traits::{FromClvm, ToClvm};
@@ -21,8 +23,13 @@ impl SingletonMember {
 }
 
 impl Mod for SingletonMember {
-    const MOD_REVEAL: &[u8] = &SINGLETON_MEMBER;
-    const MOD_HASH: TreeHash = SINGLETON_MEMBER_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&SINGLETON_MEMBER)
+    }
+
+    fn mod_hash() -> TreeHash {
+        SINGLETON_MEMBER_HASH
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]

--- a/crates/chia-sdk-types/src/puzzles/mips/n_of_n.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/n_of_n.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::TreeHash;
 use hex_literal::hex;
@@ -17,8 +19,13 @@ impl<T> NofNArgs<T> {
 }
 
 impl<T> Mod for NofNArgs<T> {
-    const MOD_REVEAL: &[u8] = &N_OF_N_PUZZLE;
-    const MOD_HASH: TreeHash = N_OF_N_PUZZLE_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&N_OF_N_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        N_OF_N_PUZZLE_HASH
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]

--- a/crates/chia-sdk-types/src/puzzles/mips/one_of_n.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/one_of_n.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_protocol::Bytes32;
 use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::TreeHash;
@@ -18,8 +20,13 @@ impl OneOfNArgs {
 }
 
 impl Mod for OneOfNArgs {
-    const MOD_REVEAL: &[u8] = &ONE_OF_N_PUZZLE;
-    const MOD_HASH: TreeHash = ONE_OF_N_PUZZLE_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&ONE_OF_N_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        ONE_OF_N_PUZZLE_HASH
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]

--- a/crates/chia-sdk-types/src/puzzles/mips/restrictions.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/restrictions.rs
@@ -5,6 +5,8 @@ mod prevent_condition_opcode;
 mod prevent_multiple_create_coins;
 mod timelock;
 
+use std::borrow::Cow;
+
 pub use force_1_of_2_restricted_variable::*;
 pub use force_assert_coin_announcement::*;
 pub use force_coin_message::*;
@@ -37,8 +39,13 @@ impl<MV, DV, I> RestrictionsArgs<MV, DV, I> {
 }
 
 impl<MV, DV, I> Mod for RestrictionsArgs<MV, DV, I> {
-    const MOD_REVEAL: &[u8] = &RESTRICTIONS_PUZZLE;
-    const MOD_HASH: TreeHash = RESTRICTIONS_PUZZLE_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&RESTRICTIONS_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        RESTRICTIONS_PUZZLE_HASH
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]

--- a/crates/chia-sdk-types/src/puzzles/mips/restrictions/force_1_of_2_restricted_variable.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/restrictions/force_1_of_2_restricted_variable.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_protocol::Bytes32;
 use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::{ToTreeHash, TreeHash};
@@ -44,8 +46,13 @@ impl Force1of2RestrictedVariable {
 }
 
 impl Mod for Force1of2RestrictedVariable {
-    const MOD_REVEAL: &[u8] = &FORCE_1_OF_2_RESTRICTED_VARIABLE_PUZZLE;
-    const MOD_HASH: TreeHash = FORCE_1_OF_2_RESTRICTED_VARIABLE_PUZZLE_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&FORCE_1_OF_2_RESTRICTED_VARIABLE_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        FORCE_1_OF_2_RESTRICTED_VARIABLE_PUZZLE_HASH
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]

--- a/crates/chia-sdk-types/src/puzzles/mips/restrictions/force_assert_coin_announcement.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/restrictions/force_assert_coin_announcement.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use clvm_utils::TreeHash;
 use hex_literal::hex;
 
@@ -7,8 +9,13 @@ use crate::Mod;
 pub struct ForceAssertCoinAnnouncementMod;
 
 impl Mod for ForceAssertCoinAnnouncementMod {
-    const MOD_REVEAL: &[u8] = &FORCE_ASSERT_COIN_ANNOUNCEMENT_PUZZLE;
-    const MOD_HASH: TreeHash = FORCE_ASSERT_COIN_ANNOUNCEMENT_PUZZLE_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&FORCE_ASSERT_COIN_ANNOUNCEMENT_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        FORCE_ASSERT_COIN_ANNOUNCEMENT_PUZZLE_HASH
+    }
 }
 
 pub const FORCE_ASSERT_COIN_ANNOUNCEMENT_PUZZLE: [u8; 85] = hex!(

--- a/crates/chia-sdk-types/src/puzzles/mips/restrictions/force_coin_message.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/restrictions/force_coin_message.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use clvm_utils::TreeHash;
 use hex_literal::hex;
 
@@ -7,8 +9,13 @@ use crate::Mod;
 pub struct ForceCoinMessageMod;
 
 impl Mod for ForceCoinMessageMod {
-    const MOD_REVEAL: &[u8] = &FORCE_COIN_MESSAGE_PUZZLE;
-    const MOD_HASH: TreeHash = FORCE_COIN_MESSAGE_PUZZLE_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&FORCE_COIN_MESSAGE_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        FORCE_COIN_MESSAGE_PUZZLE_HASH
+    }
 }
 
 pub const FORCE_COIN_MESSAGE_PUZZLE: [u8; 127] = hex!(

--- a/crates/chia-sdk-types/src/puzzles/mips/restrictions/prevent_condition_opcode.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/restrictions/prevent_condition_opcode.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::TreeHash;
 use hex_literal::hex;
@@ -17,8 +19,13 @@ impl PreventConditionOpcode {
 }
 
 impl Mod for PreventConditionOpcode {
-    const MOD_REVEAL: &[u8] = &PREVENT_CONDITION_OPCODE_PUZZLE;
-    const MOD_HASH: TreeHash = PREVENT_CONDITION_OPCODE_PUZZLE_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&PREVENT_CONDITION_OPCODE_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        PREVENT_CONDITION_OPCODE_PUZZLE_HASH
+    }
 }
 
 pub const PREVENT_CONDITION_OPCODE_PUZZLE: [u8; 131] = hex!(

--- a/crates/chia-sdk-types/src/puzzles/mips/restrictions/prevent_multiple_create_coins.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/restrictions/prevent_multiple_create_coins.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use clvm_utils::TreeHash;
 use hex_literal::hex;
 
@@ -7,8 +9,13 @@ use crate::Mod;
 pub struct PreventMultipleCreateCoinsMod;
 
 impl Mod for PreventMultipleCreateCoinsMod {
-    const MOD_REVEAL: &[u8] = &PREVENT_MULTIPLE_CREATE_COINS_PUZZLE;
-    const MOD_HASH: TreeHash = PREVENT_MULTIPLE_CREATE_COINS_PUZZLE_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&PREVENT_MULTIPLE_CREATE_COINS_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        PREVENT_MULTIPLE_CREATE_COINS_PUZZLE_HASH
+    }
 }
 
 pub const PREVENT_MULTIPLE_CREATE_COINS_PUZZLE: [u8; 143] = hex!(

--- a/crates/chia-sdk-types/src/puzzles/mips/restrictions/timelock.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/restrictions/timelock.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::TreeHash;
 use hex_literal::hex;
@@ -17,8 +19,13 @@ impl Timelock {
 }
 
 impl Mod for Timelock {
-    const MOD_REVEAL: &[u8] = &TIMELOCK_PUZZLE;
-    const MOD_HASH: TreeHash = TIMELOCK_PUZZLE_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&TIMELOCK_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        TIMELOCK_PUZZLE_HASH
+    }
 }
 
 pub const TIMELOCK_PUZZLE: [u8; 137] = hex!(

--- a/crates/chia-sdk-types/src/puzzles/mods.rs
+++ b/crates/chia-sdk-types/src/puzzles/mods.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_puzzles::{
     NFT_METADATA_UPDATER_DEFAULT, NFT_METADATA_UPDATER_DEFAULT_HASH, SETTLEMENT_PAYMENT,
     SETTLEMENT_PAYMENT_HASH, SINGLETON_LAUNCHER, SINGLETON_LAUNCHER_HASH,
@@ -10,22 +12,37 @@ use crate::Mod;
 pub struct NftMetadataUpdater;
 
 impl Mod for NftMetadataUpdater {
-    const MOD_REVEAL: &[u8] = &NFT_METADATA_UPDATER_DEFAULT;
-    const MOD_HASH: TreeHash = TreeHash::new(NFT_METADATA_UPDATER_DEFAULT_HASH);
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&NFT_METADATA_UPDATER_DEFAULT)
+    }
+
+    fn mod_hash() -> TreeHash {
+        TreeHash::new(NFT_METADATA_UPDATER_DEFAULT_HASH)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SingletonLauncher;
 
 impl Mod for SingletonLauncher {
-    const MOD_REVEAL: &[u8] = &SINGLETON_LAUNCHER;
-    const MOD_HASH: TreeHash = TreeHash::new(SINGLETON_LAUNCHER_HASH);
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&SINGLETON_LAUNCHER)
+    }
+
+    fn mod_hash() -> TreeHash {
+        TreeHash::new(SINGLETON_LAUNCHER_HASH)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SettlementPayment;
 
 impl Mod for SettlementPayment {
-    const MOD_REVEAL: &[u8] = &SETTLEMENT_PAYMENT;
-    const MOD_HASH: TreeHash = TreeHash::new(SETTLEMENT_PAYMENT_HASH);
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&SETTLEMENT_PAYMENT)
+    }
+
+    fn mod_hash() -> TreeHash {
+        TreeHash::new(SETTLEMENT_PAYMENT_HASH)
+    }
 }

--- a/crates/chia-sdk-types/src/puzzles/option_contract.rs
+++ b/crates/chia-sdk-types/src/puzzles/option_contract.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_protocol::Bytes32;
 use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::TreeHash;
@@ -42,8 +44,13 @@ impl<I> OptionContractSolution<I> {
 }
 
 impl<I> Mod for OptionContractArgs<I> {
-    const MOD_REVEAL: &[u8] = &OPTION_CONTRACT_PUZZLE;
-    const MOD_HASH: TreeHash = OPTION_CONTRACT_PUZZLE_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&OPTION_CONTRACT_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        OPTION_CONTRACT_PUZZLE_HASH
+    }
 }
 
 pub const OPTION_CONTRACT_PUZZLE: [u8; 862] = hex!(

--- a/crates/chia-sdk-types/src/puzzles/p2_curried.rs
+++ b/crates/chia-sdk-types/src/puzzles/p2_curried.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_protocol::Bytes32;
 use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::TreeHash;
@@ -18,8 +20,13 @@ impl P2CurriedArgs {
 }
 
 impl Mod for P2CurriedArgs {
-    const MOD_REVEAL: &[u8] = &P2_CURRIED_PUZZLE;
-    const MOD_HASH: TreeHash = P2_CURRIED_PUZZLE_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&P2_CURRIED_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        P2_CURRIED_PUZZLE_HASH
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]

--- a/crates/chia-sdk-types/src/puzzles/p2_delegated_conditions.rs
+++ b/crates/chia-sdk-types/src/puzzles/p2_delegated_conditions.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_bls::PublicKey;
 use chia_puzzles::{P2_DELEGATED_CONDITIONS, P2_DELEGATED_CONDITIONS_HASH};
 use clvm_traits::{FromClvm, ToClvm};
@@ -19,8 +21,13 @@ impl P2DelegatedConditionsArgs {
 }
 
 impl Mod for P2DelegatedConditionsArgs {
-    const MOD_REVEAL: &[u8] = &P2_DELEGATED_CONDITIONS;
-    const MOD_HASH: TreeHash = TreeHash::new(P2_DELEGATED_CONDITIONS_HASH);
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&P2_DELEGATED_CONDITIONS)
+    }
+
+    fn mod_hash() -> TreeHash {
+        P2_DELEGATED_CONDITIONS_HASH.into()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]

--- a/crates/chia-sdk-types/src/puzzles/p2_one_of_many.rs
+++ b/crates/chia-sdk-types/src/puzzles/p2_one_of_many.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_protocol::Bytes32;
 use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::TreeHash;
@@ -18,8 +20,13 @@ impl P2OneOfManyArgs {
 }
 
 impl Mod for P2OneOfManyArgs {
-    const MOD_REVEAL: &[u8] = &P2_ONE_OF_MANY_PUZZLE;
-    const MOD_HASH: TreeHash = P2_ONE_OF_MANY_PUZZLE_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&P2_ONE_OF_MANY_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        P2_ONE_OF_MANY_PUZZLE_HASH
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]

--- a/crates/chia-sdk-types/src/puzzles/p2_singleton.rs
+++ b/crates/chia-sdk-types/src/puzzles/p2_singleton.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_protocol::Bytes32;
 use chia_puzzles::{SINGLETON_LAUNCHER_HASH, SINGLETON_TOP_LAYER_V1_1_HASH};
 use clvm_traits::{FromClvm, ToClvm};
@@ -15,8 +17,13 @@ pub struct P2SingletonArgs {
 }
 
 impl Mod for P2SingletonArgs {
-    const MOD_REVEAL: &[u8] = &P2_SINGLETON_PUZZLE;
-    const MOD_HASH: TreeHash = P2_SINGLETON_PUZZLE_HASH;
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&P2_SINGLETON_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        P2_SINGLETON_PUZZLE_HASH
+    }
 }
 
 impl P2SingletonArgs {

--- a/crates/chia-sdk-types/src/puzzles/revocation.rs
+++ b/crates/chia-sdk-types/src/puzzles/revocation.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chia_protocol::Bytes32;
 use chia_puzzles::{REVOCATION_LAYER, REVOCATION_LAYER_HASH};
 use clvm_traits::{FromClvm, ToClvm};
@@ -24,8 +26,13 @@ impl RevocationArgs {
 }
 
 impl Mod for RevocationArgs {
-    const MOD_REVEAL: &[u8] = &REVOCATION_LAYER;
-    const MOD_HASH: TreeHash = TreeHash::new(REVOCATION_LAYER_HASH);
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&REVOCATION_LAYER)
+    }
+
+    fn mod_hash() -> TreeHash {
+        TreeHash::new(REVOCATION_LAYER_HASH)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]


### PR DESCRIPTION
Adds a `load_clvm` utility that is meant to work similarly to the Python equivalent - it loads a Chialisp file and compiles it into CLVM, returning both the puzzle reveal and hash (for use with the current `Mod` architecture). This necessitates also changing `Mod` to use functions instead of constants.