### PR TITLE
Set up for trusted publishing

### DIFF
--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -19,7 +19,8 @@ env:
   MACOSX_DEPLOYMENT_TARGET: "10.13"
 
 permissions:
-  contents: write
+  contents: read
+  actions: write
   id-token: write
 
 jobs:
@@ -375,8 +376,6 @@ jobs:
         if: startsWith(github.event.ref, 'refs/tags')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npm config set provenance true
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
           npm publish --access public

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -13,6 +13,11 @@ concurrency:
   group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow_ref, github.event.pull_request.number) || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  actions: write
+  id-token: write
+
 jobs:
   build:
     name: Build
@@ -61,7 +66,7 @@ jobs:
 
       - name: Publish
         if: startsWith(github.event.ref, 'refs/tags')
-        uses: JS-DevTools/npm-publish@v3
+        uses: JS-DevTools/npm-publish@v4
         with:
-          token: ${{ secrets.NPM_TOKEN }}
+          provenance: true
           package: wasm/pkg/package.json


### PR DESCRIPTION
This PR updates the npm publishing workflows to use Trusted Publishing via GitHub Actions OIDC instead of long-lived npm access tokens. It also enables build provenance, allowing consumers to verify that published packages were built and released from the official CI workflow.