### PR TITLE
15% wasm size reduction (5.2MB -> 4.4MB) using binaryen optimizations

### DIFF
--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -34,5 +34,15 @@ console_error_panic_hook = { workspace = true }
 [package.metadata.cargo-machete]
 ignored = ["chia-sdk-bindings", "getrandom", "wasm-bindgen-futures", "js-sys"]
 
+# Optimize for smallest WASM size (release profile used by wasm-pack build)
+[profile.release]
+opt-level = "z"
+lto = true
+strip = "symbols"
+
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = false
+# Binaryen wasm-opt; -Oz prioritizes size over speed.
+# Enable features used by Rust/LLVM output so the validator accepts them:
+# - bulk-memory-opt: memory.copy, memory.fill
+# - nontrapping-float-to-int: i32.trunc_sat_f64_u, i64.trunc_sat_f64_s, etc.
+wasm-opt = ["-Oz", "--enable-bulk-memory-opt", "--enable-nontrapping-float-to-int"]

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -8,6 +8,7 @@
     "@types/node": "^24.0.13",
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "ava": "^6.4.1",
+    "binaryen": "^125.0.0",
     "ts-node": "^10.9.2"
   },
   "ava": {

--- a/wasm/pnpm-lock.yaml
+++ b/wasm/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       ava:
         specifier: ^6.4.1
         version: 6.4.1(@ava/typescript@6.0.0)
+      binaryen:
+        specifier: ^125.0.0
+        version: 125.0.0
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@24.0.13)(typescript@5.8.3)
@@ -191,6 +194,10 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  binaryen@125.0.0:
+    resolution: {integrity: sha512-X7CUM9ZnwL/Ow++JH5AJKiemc82J7JyeryuPvXQdXBLcL/rqrC5KMUB1mHiORSolietH9sotvaOZlr6HSwPAlw==}
+    hasBin: true
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -1037,6 +1044,8 @@ snapshots:
       - supports-color
 
   balanced-match@1.0.2: {}
+
+  binaryen@125.0.0: {}
 
   bindings@1.5.0:
     dependencies:


### PR DESCRIPTION
Creating PR to trigger the CI. It's possible that the optimization may have broke things.

---

Turns out the default optimization of `-O` outperforms the size-minifying `-Oz` in size,  so I'll update this to switch to that and attempt to fix the build error. 