### PR TITLE
Fix simulator debug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,6 +714,7 @@ dependencies = [
  "chia-sha2 0.36.1",
  "clvm-traits 0.36.1",
  "clvmr",
+ "colored",
  "hex",
  "hex-literal",
  "k256",
@@ -1174,11 +1175,11 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
-version = "3.0.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,7 @@ bincode = "2.0.1"
 rue-compiler = "0.6.0"
 rue-options = "0.6.0"
 rue-lir = "0.6.0"
+colored = "3.1.1"
 
 [profile.release]
 lto = true

--- a/crates/chia-sdk-signer/Cargo.toml
+++ b/crates/chia-sdk-signer/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = { workspace = true }
 chia-sdk-types = { workspace = true }
 k256 = { workspace = true }
 rue-lir = { workspace = true }
+colored = { workspace = true }
 
 [dev-dependencies]
 chia-puzzle-types = { workspace = true }

--- a/crates/chia-sdk-signer/src/required_signature.rs
+++ b/crates/chia-sdk-signer/src/required_signature.rs
@@ -4,6 +4,7 @@ use clvm_traits::{FromClvm, ToClvm};
 use clvmr::{
     Allocator, ChiaDialect, ENABLE_KECCAK_OPS_OUTSIDE_GUARD, dialect::Dialect, run_program,
 };
+use colored::Colorize;
 use rue_lir::DebugDialect;
 
 use crate::{
@@ -26,18 +27,24 @@ impl RequiredSignature {
         constants: &AggSigConstants,
     ) -> Result<Vec<Self>, SignerError> {
         if is_debug_dialect_enabled() {
-            Self::from_coin_spend_with_dialect(
-                allocator,
-                coin_spend,
-                constants,
-                DebugDialect::new(ENABLE_KECCAK_OPS_OUTSIDE_GUARD, false),
-            )
+            let dialect = DebugDialect::new(ENABLE_KECCAK_OPS_OUTSIDE_GUARD, false);
+
+            let result =
+                Self::from_coin_spend_with_dialect(allocator, coin_spend, constants, &dialect);
+
+            if result.is_err() {
+                for item in dialect.log() {
+                    eprintln!("{}: {}", item.srcloc.cyan().bold(), item.message);
+                }
+            }
+
+            result
         } else {
             Self::from_coin_spend_with_dialect(
                 allocator,
                 coin_spend,
                 constants,
-                ChiaDialect::new(0),
+                &ChiaDialect::new(0),
             )
         }
     }
@@ -46,7 +53,7 @@ impl RequiredSignature {
         allocator: &mut Allocator,
         coin_spend: &CoinSpend,
         constants: &AggSigConstants,
-        dialect: D,
+        dialect: &D,
     ) -> Result<Vec<Self>, SignerError> {
         let puzzle = coin_spend.puzzle_reveal.to_clvm(allocator)?;
         let solution = coin_spend.solution.to_clvm(allocator)?;

--- a/crates/chia-sdk-signer/src/secp/secp_dialect.rs
+++ b/crates/chia-sdk-signer/src/secp/secp_dialect.rs
@@ -35,7 +35,7 @@ impl<T> SecpDialect<T> {
     }
 }
 
-impl<T> Dialect for SecpDialect<T>
+impl<T> Dialect for SecpDialect<&T>
 where
     T: Dialect,
 {
@@ -138,7 +138,8 @@ mod tests {
         )
         .to_clvm(&mut a)?;
 
-        let dialect = SecpDialect::new(ChiaDialect::new(0));
+        let dialect = ChiaDialect::new(0);
+        let dialect = SecpDialect::new(&dialect);
 
         let reduction = run_program(&mut a, &dialect, program, NodePtr::NIL, u64::MAX).unwrap();
         let mut collected = dialect.collect();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to debug/error-reporting and dialect wrapper plumbing; runtime behavior should be unchanged except for additional stderr output on debug failures.
> 
> **Overview**
> When `is_debug_dialect_enabled()` is on, `RequiredSignature::from_coin_spend` now keeps a `DebugDialect` instance and, on error, prints its collected log entries (with colored srclocs) to stderr to aid simulator/debug failures.
> 
> To support this, `from_coin_spend_with_dialect` and `SecpDialect` were adjusted to operate on a borrowed dialect (`&D` / `SecpDialect<&T>`) rather than consuming it, and the workspace adds the `colored` dependency (plus a lockfile bump).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7499456eca6a5b9b9292b573f3362d7470dcb8b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->