### PR TITLE
Add Chia daemon websocket client (chia-sdk-daemon)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,6 +924,7 @@ dependencies = [
  "chia-puzzles",
  "chia-sdk-client",
  "chia-sdk-coinset",
+ "chia-sdk-daemon",
  "chia-sdk-driver",
  "chia-sdk-signer",
  "chia-sdk-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,6 +657,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "chia-sdk-daemon"
+version = "0.33.0"
+dependencies = [
+ "chia-sdk-client",
+ "chia-sdk-coinset",
+ "futures-util",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "tungstenite",
+]
+
+[[package]]
 name = "chia-sdk-derive"
 version = "0.33.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ chia-sdk-types = { version = "0.33.0", path = "./crates/chia-sdk-types" }
 chia-sdk-derive = { version = "0.33.0", path = "./crates/chia-sdk-types/derive" }
 chia-sdk-utils = { version = "0.33.0", path = "./crates/chia-sdk-utils" }
 chia-sdk-coinset = { version = "0.33.0", path = "./crates/chia-sdk-coinset" }
+chia-sdk-daemon = { version = "0.33.0", path = "./crates/chia-sdk-daemon" }
 chia-sdk-bindings = { version = "0.33.0", path = "./crates/chia-sdk-bindings" }
 bindy = { version = "0.33.0", path = "./crates/chia-sdk-bindings/bindy" }
 bindy-macro = { version = "0.33.0", path = "./crates/chia-sdk-bindings/bindy-macro" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,8 +72,8 @@ workspace = true
 [features]
 chip-0035 = ["chia-sdk-driver/chip-0035", "chia-sdk-types/chip-0035"]
 offer-compression = ["chia-sdk-driver/offer-compression"]
-native-tls = ["chia-sdk-client/native-tls", "chia-sdk-coinset/native-tls"]
-rustls = ["chia-sdk-client/rustls", "chia-sdk-coinset/rustls"]
+native-tls = ["chia-sdk-client/native-tls", "chia-sdk-coinset/native-tls", "chia-sdk-daemon/native-tls"]
+rustls = ["chia-sdk-client/rustls", "chia-sdk-coinset/rustls", "chia-sdk-daemon/rustls"]
 peer-simulator = ["chia-sdk-test/peer-simulator"]
 action-layer = ["chia-sdk-types/action-layer", "chia-sdk-driver/action-layer"]
 
@@ -85,6 +85,7 @@ chia-sdk-test = { workspace = true, features = ["serde"] }
 chia-sdk-types = { workspace = true }
 chia-sdk-utils = { workspace = true }
 chia-sdk-coinset = { workspace = true }
+chia-sdk-daemon = { workspace = true }
 chia-protocol = { workspace = true, features = ["serde"] }
 chia-bls = { workspace = true, features = ["serde"] }
 chia-secp = { workspace = true }

--- a/crates/chia-sdk-daemon/Cargo.toml
+++ b/crates/chia-sdk-daemon/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.33.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Chia daemon websocket client with RPC support via ChiaRpcClient trait."
-authors = ["Brandon Haggstrom <me@rigidnetwork.com>"]
+authors = ["Brandon Haggstrom <me@rigidnetwork.com>", "Chris Marslender <chrismarslender@gmail.com>"]
 homepage = "https://github.com/xch-dev/chia-wallet-sdk"
 repository = "https://github.com/xch-dev/chia-wallet-sdk"
 readme = { workspace = true }

--- a/crates/chia-sdk-daemon/Cargo.toml
+++ b/crates/chia-sdk-daemon/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "chia-sdk-daemon"
+version = "0.33.0"
+edition = "2024"
+license = "Apache-2.0"
+description = "Chia daemon websocket client with RPC support via ChiaRpcClient trait."
+authors = ["Brandon Haggstrom <me@rigidnetwork.com>"]
+homepage = "https://github.com/xch-dev/chia-wallet-sdk"
+repository = "https://github.com/xch-dev/chia-wallet-sdk"
+readme = { workspace = true }
+keywords = { workspace = true }
+categories = { workspace = true }
+
+[lints]
+workspace = true
+
+[features]
+native-tls = ["chia-sdk-client/native-tls"]
+rustls = ["chia-sdk-client/rustls"]
+
+[dependencies]
+chia-sdk-coinset = { workspace = true }
+chia-sdk-client = { workspace = true }
+tokio-tungstenite = { workspace = true }
+tungstenite = { workspace = true }
+tokio = { workspace = true, features = ["sync", "time", "rt"] }
+futures-util = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }

--- a/crates/chia-sdk-daemon/Cargo.toml
+++ b/crates/chia-sdk-daemon/Cargo.toml
@@ -29,3 +29,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+
+[package.metadata.cargo-machete]
+ignored = ["chia-sdk-client"]

--- a/crates/chia-sdk-daemon/README.md
+++ b/crates/chia-sdk-daemon/README.md
@@ -1,0 +1,85 @@
+# chia-sdk-daemon
+
+A Chia daemon websocket client. Connects to the Chia daemon over WSS (mTLS), supports RPC calls routed through the daemon (via the `ChiaRpcClient` trait), and event subscriptions via broadcast channels.
+
+## Setup
+
+Add the crate with one of the TLS features enabled:
+
+```toml
+[dependencies]
+chia-sdk-daemon = { version = "0.33.0", features = ["native-tls"] }
+# or
+chia-sdk-daemon = { version = "0.33.0", features = ["rustls"] }
+```
+
+## Connecting to the Daemon
+
+```rust
+use std::time::Duration;
+
+use chia_sdk_client::{create_native_tls_connector, load_ssl_cert};
+use chia_sdk_daemon::DaemonClient;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cert = load_ssl_cert(
+        "~/.chia/mainnet/config/ssl/daemon/private_daemon.crt",
+        "~/.chia/mainnet/config/ssl/daemon/private_daemon.key",
+    )?;
+    let connector = create_native_tls_connector(&cert)?;
+
+    let client = DaemonClient::connect(
+        "wss://localhost:55400",
+        connector,
+        Duration::from_secs(30),
+    )
+    .await?;
+
+    // ... use client ...
+
+    client.close().await?;
+    Ok(())
+}
+```
+
+## Making RPC Calls
+
+`DaemonClient` implements `ChiaRpcClient`, so all full_node RPC methods are available directly. Requests are routed through the daemon websocket to `chia_full_node`.
+
+```rust
+use chia_sdk_coinset::ChiaRpcClient;
+
+let state = client.get_blockchain_state().await?;
+println!("Peak height: {}", state.blockchain_state.unwrap().peak.height);
+
+let record = client.get_block_record_by_height(1000).await?;
+println!("Block record: {:?}", record.block_record);
+```
+
+## Subscribing to Events
+
+Use `subscribe` to register for daemon events and receive them via a broadcast channel. This sends a `register_service` command to the daemon for the given service name.
+
+```rust
+use chia_sdk_daemon::DaemonEvent;
+
+let mut receiver = client.subscribe("metrics").await?;
+
+tokio::spawn(async move {
+    loop {
+        match receiver.recv().await {
+            Ok(event) => {
+                println!("Event: {} from {}", event.command, event.origin);
+                println!("Data: {}", event.data);
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                eprintln!("Missed {n} events");
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                break;
+            }
+        }
+    }
+});
+```

--- a/crates/chia-sdk-daemon/src/client.rs
+++ b/crates/chia-sdk-daemon/src/client.rs
@@ -161,10 +161,9 @@ mod inner {
             &self,
             service: &str,
         ) -> Result<broadcast::Receiver<DaemonEvent>, DaemonError> {
-            self.register_service(service).await?;
-
             let mut subs = self.0.subscriptions.lock().await;
             if !subs.iter().any(|s| s == service) {
+                self.register_service(service).await?;
                 subs.push(service.to_string());
             }
 

--- a/crates/chia-sdk-daemon/src/client.rs
+++ b/crates/chia-sdk-daemon/src/client.rs
@@ -1,270 +1,455 @@
-use std::{
-    collections::HashMap,
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
-    time::Duration,
-};
-
-use chia_sdk_coinset::ChiaRpcClient;
-use futures_util::{
-    SinkExt, StreamExt,
-    stream::{SplitSink, SplitStream},
-};
-use serde::{Serialize, de::DeserializeOwned};
-use tokio::{
-    net::TcpStream,
-    sync::{Mutex, broadcast, oneshot},
-    task::JoinHandle,
-};
-use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
-use tracing::{debug, warn};
-
 #[cfg(any(feature = "native-tls", feature = "rustls"))]
-use tokio_tungstenite::Connector;
+mod inner {
+    use std::{
+        collections::HashMap,
+        sync::{
+            Arc,
+            atomic::{AtomicU32, AtomicU64, Ordering},
+        },
+        time::Duration,
+    };
 
-use crate::{DaemonError, DaemonEvent, WebsocketRequest, WebsocketResponse};
+    use chia_sdk_coinset::ChiaRpcClient;
+    use futures_util::{
+        SinkExt, StreamExt,
+        stream::{SplitSink, SplitStream},
+    };
+    use serde::{Serialize, de::DeserializeOwned};
+    use tokio::{
+        net::TcpStream,
+        sync::{Mutex, broadcast, oneshot, watch},
+        task::JoinHandle,
+    };
+    use tokio_tungstenite::{Connector, MaybeTlsStream, WebSocketStream};
+    use tracing::{debug, error, info, warn};
 
-type WebSocket = WebSocketStream<MaybeTlsStream<TcpStream>>;
-type Sink = SplitSink<WebSocket, tungstenite::Message>;
-type Stream = SplitStream<WebSocket>;
+    use crate::{DaemonError, DaemonEvent, WebsocketRequest, WebsocketResponse};
 
-static REQUEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+    type WebSocket = WebSocketStream<MaybeTlsStream<TcpStream>>;
+    type Sink = SplitSink<WebSocket, tungstenite::Message>;
+    type Stream = SplitStream<WebSocket>;
 
-fn next_request_id() -> String {
-    REQUEST_COUNTER.fetch_add(1, Ordering::Relaxed).to_string()
-}
+    static REQUEST_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-#[derive(Debug)]
-pub struct DaemonClient(Arc<DaemonClientInner>);
+    fn next_request_id() -> String {
+        REQUEST_COUNTER.fetch_add(1, Ordering::Relaxed).to_string()
+    }
 
-#[derive(Debug)]
-struct DaemonClientInner {
-    base_url: String,
-    origin: String,
-    sink: Mutex<Sink>,
-    pending: Arc<Mutex<HashMap<String, oneshot::Sender<serde_json::Value>>>>,
-    event_tx: broadcast::Sender<DaemonEvent>,
-    timeout: Duration,
-    reader_handle: JoinHandle<()>,
-}
+    #[derive(Debug)]
+    pub struct DaemonClient(Arc<DaemonClientInner>);
 
-impl DaemonClient {
-    /// Connects to the Chia daemon over WSS.
-    ///
-    /// The `connector` should be built from TLS helpers in `chia-sdk-client`
-    /// (e.g. `create_native_tls_connector` or `create_rustls_connector`)
-    /// using the daemon's SSL certificate and key.
-    #[cfg(any(feature = "native-tls", feature = "rustls"))]
-    pub async fn connect(
-        url: &str,
-        connector: Connector,
+    struct DaemonClientInner {
+        base_url: String,
+        origin: String,
+        sink: Mutex<Sink>,
+        pending: Arc<Mutex<HashMap<String, oneshot::Sender<serde_json::Value>>>>,
+        event_tx: broadcast::Sender<DaemonEvent>,
         timeout: Duration,
-    ) -> Result<Self, DaemonError> {
-        let (ws, _) =
-            tokio_tungstenite::connect_async_tls_with_config(url, None, false, Some(connector))
-                .await?;
-
-        let (sink, stream) = ws.split();
-
-        let pending: Arc<Mutex<HashMap<String, oneshot::Sender<serde_json::Value>>>> =
-            Arc::new(Mutex::new(HashMap::new()));
-        let (event_tx, _) = broadcast::channel::<DaemonEvent>(256);
-
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0);
-        let origin = format!("chia-wallet-sdk-{nanos}");
-
-        let pending_clone = pending.clone();
-        let event_tx_clone = event_tx.clone();
-
-        let reader_handle = tokio::spawn(async move {
-            if let Err(error) = handle_inbound_messages(stream, pending_clone, event_tx_clone).await
-            {
-                debug!("Daemon reader task ended: {error}");
-            }
-        });
-
-        let client = Self(Arc::new(DaemonClientInner {
-            base_url: url.to_string(),
-            origin,
-            sink: Mutex::new(sink),
-            pending,
-            event_tx,
-            timeout,
-            reader_handle,
-        }));
-
-        client.register_service(&client.0.origin.clone()).await?;
-
-        Ok(client)
+        reader_handle: Mutex<Option<JoinHandle<()>>>,
+        connector: Connector,
+        subscriptions: Mutex<Vec<String>>,
+        connected: watch::Sender<bool>,
+        max_reconnect_attempts: AtomicU32,
+        disconnect_tx: broadcast::Sender<()>,
+        reconnect_tx: broadcast::Sender<()>,
     }
 
-    /// Returns a receiver for daemon events (e.g. metrics, state changes).
-    ///
-    /// Calling `subscribe` also sends a `register_service` command to the daemon
-    /// for the given service name, so that the daemon will forward events for
-    /// that service to this client.
-    pub async fn subscribe(
-        &self,
-        service: &str,
-    ) -> Result<broadcast::Receiver<DaemonEvent>, DaemonError> {
-        self.register_service(service).await?;
-        Ok(self.0.event_tx.subscribe())
-    }
-
-    async fn register_service(&self, service: &str) -> Result<(), DaemonError> {
-        let request_id = next_request_id();
-
-        let request = WebsocketRequest {
-            command: "register_service".to_string(),
-            ack: false,
-            origin: self.0.origin.clone(),
-            destination: "daemon".to_string(),
-            request_id,
-            data: serde_json::json!({ "service": service }),
-        };
-
-        let msg = serde_json::to_string(&request)?;
-        self.0
-            .sink
-            .lock()
-            .await
-            .send(tungstenite::Message::Text(msg))
-            .await
-            .map_err(|_| DaemonError::SendFailed)?;
-
-        Ok(())
-    }
-
-    /// Closes the websocket connection and aborts the background reader task.
-    pub async fn close(&self) -> Result<(), DaemonError> {
-        self.0.sink.lock().await.close().await?;
-        Ok(())
-    }
-
-    async fn send_request<R>(
-        &self,
-        command: &str,
-        destination: &str,
-        data: serde_json::Value,
-    ) -> Result<R, DaemonError>
-    where
-        R: DeserializeOwned + Send,
-    {
-        let request_id = next_request_id();
-
-        let request = WebsocketRequest {
-            command: command.to_string(),
-            ack: false,
-            origin: self.0.origin.clone(),
-            destination: destination.to_string(),
-            request_id: request_id.clone(),
-            data,
-        };
-
-        let (tx, rx) = oneshot::channel();
-        self.0.pending.lock().await.insert(request_id.clone(), tx);
-
-        let msg = serde_json::to_string(&request)?;
-        self.0
-            .sink
-            .lock()
-            .await
-            .send(tungstenite::Message::Text(msg))
-            .await
-            .map_err(|_| DaemonError::SendFailed)?;
-
-        let value = tokio::time::timeout(self.0.timeout, rx)
-            .await
-            .map_err(|_| {
-                // Timed out -- clean up the pending entry so the reader
-                // doesn't try to send to a closed channel later.
-                let pending = self.0.pending.clone();
-                let id = request_id.clone();
-                tokio::spawn(async move { pending.lock().await.remove(&id) });
-                DaemonError::Timeout(self.0.timeout)
-            })?
-            .map_err(|_| DaemonError::ReceiveFailed)?;
-
-        Ok(serde_json::from_value(value)?)
-    }
-}
-
-impl Clone for DaemonClient {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
-
-impl ChiaRpcClient for DaemonClient {
-    type Error = DaemonError;
-
-    fn base_url(&self) -> &str {
-        &self.0.base_url
-    }
-
-    async fn make_post_request<R, B>(&self, endpoint: &str, body: B) -> Result<R, Self::Error>
-    where
-        B: Serialize + Send,
-        R: DeserializeOwned + Send,
-    {
-        let data = serde_json::to_value(body)?;
-        self.send_request(endpoint, "chia_full_node", data).await
-    }
-}
-
-impl Drop for DaemonClientInner {
-    fn drop(&mut self) {
-        self.reader_handle.abort();
-    }
-}
-
-async fn handle_inbound_messages(
-    mut stream: Stream,
-    pending: Arc<Mutex<HashMap<String, oneshot::Sender<serde_json::Value>>>>,
-    event_tx: broadcast::Sender<DaemonEvent>,
-) -> Result<(), DaemonError> {
-    while let Some(message) = stream.next().await {
-        let message = message?;
-
-        let text = match message {
-            tungstenite::Message::Text(text) => text,
-            tungstenite::Message::Binary(bin) => {
-                String::from_utf8(bin).map_err(|_| DaemonError::ConnectionClosed)?
-            }
-            tungstenite::Message::Close(..) => break,
-            tungstenite::Message::Ping(..) | tungstenite::Message::Pong(..) => continue,
-            _ => continue,
-        };
-
-        let response: WebsocketResponse = match serde_json::from_str(&text) {
-            Ok(resp) => resp,
-            Err(e) => {
-                warn!("Failed to parse daemon message: {e}");
-                continue;
-            }
-        };
-
-        let mut pending_guard = pending.lock().await;
-        if let Some(sender) = pending_guard.remove(&response.request_id) {
-            drop(pending_guard);
-            sender.send(response.data).ok();
-        } else {
-            drop(pending_guard);
-
-            let event = DaemonEvent {
-                command: response.command,
-                origin: response.origin,
-                data: response.data,
-            };
-
-            event_tx.send(event).ok();
+    impl std::fmt::Debug for DaemonClientInner {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("DaemonClientInner")
+                .field("base_url", &self.base_url)
+                .field("origin", &self.origin)
+                .field("timeout", &self.timeout)
+                .finish_non_exhaustive()
         }
     }
 
-    Ok(())
+    impl DaemonClient {
+        /// Connects to the Chia daemon over WSS.
+        ///
+        /// The `connector` should be built from TLS helpers in `chia-sdk-client`
+        /// (e.g. `create_native_tls_connector` or `create_rustls_connector`)
+        /// using the daemon's SSL certificate and key.
+        pub async fn connect(
+            url: &str,
+            connector: Connector,
+            timeout: Duration,
+        ) -> Result<Self, DaemonError> {
+            let (ws, _) = tokio_tungstenite::connect_async_tls_with_config(
+                url,
+                None,
+                false,
+                Some(connector.clone()),
+            )
+            .await?;
+
+            let (sink, stream) = ws.split();
+
+            let pending: Arc<Mutex<HashMap<String, oneshot::Sender<serde_json::Value>>>> =
+                Arc::new(Mutex::new(HashMap::new()));
+            let (event_tx, _) = broadcast::channel::<DaemonEvent>(256);
+
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0);
+            let origin = format!("chia-wallet-sdk-{nanos}");
+
+            let (connected_tx, _) = watch::channel(true);
+            let (disconnect_tx, _) = broadcast::channel::<()>(16);
+            let (reconnect_tx, _) = broadcast::channel::<()>(16);
+
+            let inner = Arc::new(DaemonClientInner {
+                base_url: url.to_string(),
+                origin,
+                sink: Mutex::new(sink),
+                pending,
+                event_tx,
+                timeout,
+                reader_handle: Mutex::new(None),
+                connector,
+                subscriptions: Mutex::new(Vec::new()),
+                connected: connected_tx,
+                max_reconnect_attempts: AtomicU32::new(u32::MAX),
+                disconnect_tx,
+                reconnect_tx,
+            });
+
+            let pending_clone = inner.pending.clone();
+            let event_tx_clone = inner.event_tx.clone();
+            let inner_for_reader = inner.clone();
+
+            let reader_handle = tokio::spawn(async move {
+                if let Err(error) =
+                    handle_inbound_messages(stream, pending_clone, event_tx_clone).await
+                {
+                    debug!("Daemon reader task ended: {error}");
+                    if let Err(e) = Self::reconnect(inner_for_reader).await {
+                        error!("Reconnection failed permanently: {e}");
+                    }
+                }
+            });
+
+            *inner.reader_handle.lock().await = Some(reader_handle);
+
+            let client = Self(inner);
+
+            // Register own origin first, then track it for reconnection
+            client.register_service(&client.0.origin.clone()).await?;
+            client
+                .0
+                .subscriptions
+                .lock()
+                .await
+                .push(client.0.origin.clone());
+
+            Ok(client)
+        }
+
+        /// Returns a receiver for daemon events (e.g. metrics, state changes).
+        ///
+        /// Calling `subscribe` also sends a `register_service` command to the daemon
+        /// for the given service name, so that the daemon will forward events for
+        /// that service to this client.
+        pub async fn subscribe(
+            &self,
+            service: &str,
+        ) -> Result<broadcast::Receiver<DaemonEvent>, DaemonError> {
+            self.register_service(service).await?;
+
+            let mut subs = self.0.subscriptions.lock().await;
+            if !subs.iter().any(|s| s == service) {
+                subs.push(service.to_string());
+            }
+
+            Ok(self.0.event_tx.subscribe())
+        }
+
+        async fn register_service(&self, service: &str) -> Result<(), DaemonError> {
+            let request_id = next_request_id();
+
+            let request = WebsocketRequest {
+                command: "register_service".to_string(),
+                ack: false,
+                origin: self.0.origin.clone(),
+                destination: "daemon".to_string(),
+                request_id,
+                data: serde_json::json!({ "service": service }),
+            };
+
+            let msg = serde_json::to_string(&request)?;
+            self.0
+                .sink
+                .lock()
+                .await
+                .send(tungstenite::Message::Text(msg))
+                .await
+                .map_err(|_| DaemonError::SendFailed)?;
+
+            Ok(())
+        }
+
+        /// Closes the websocket connection and aborts the background reader task.
+        pub async fn close(&self) -> Result<(), DaemonError> {
+            self.0.sink.lock().await.close().await?;
+            Ok(())
+        }
+
+        /// Returns a receiver that fires when the connection is lost.
+        pub fn on_disconnect(&self) -> broadcast::Receiver<()> {
+            self.0.disconnect_tx.subscribe()
+        }
+
+        /// Returns a receiver that fires when the connection is re-established after a disconnect.
+        pub fn on_reconnect(&self) -> broadcast::Receiver<()> {
+            self.0.reconnect_tx.subscribe()
+        }
+
+        /// Sets the maximum number of reconnection attempts before giving up.
+        /// `None` means unlimited (the default).
+        pub fn set_max_reconnect_attempts(&self, max: Option<u32>) {
+            self.0
+                .max_reconnect_attempts
+                .store(max.unwrap_or(u32::MAX), Ordering::Relaxed);
+        }
+
+        async fn send_request<R>(
+            &self,
+            command: &str,
+            destination: &str,
+            data: serde_json::Value,
+        ) -> Result<R, DaemonError>
+        where
+            R: DeserializeOwned + Send,
+        {
+            if !*self.0.connected.subscribe().borrow() {
+                return Err(DaemonError::ConnectionClosed);
+            }
+
+            let request_id = next_request_id();
+
+            let request = WebsocketRequest {
+                command: command.to_string(),
+                ack: false,
+                origin: self.0.origin.clone(),
+                destination: destination.to_string(),
+                request_id: request_id.clone(),
+                data,
+            };
+
+            let (tx, rx) = oneshot::channel();
+            self.0.pending.lock().await.insert(request_id.clone(), tx);
+
+            let msg = serde_json::to_string(&request)?;
+            self.0
+                .sink
+                .lock()
+                .await
+                .send(tungstenite::Message::Text(msg))
+                .await
+                .map_err(|_| DaemonError::SendFailed)?;
+
+            let value = tokio::time::timeout(self.0.timeout, rx)
+                .await
+                .map_err(|_| {
+                    // Timed out -- clean up the pending entry so the reader
+                    // doesn't try to send to a closed channel later.
+                    let pending = self.0.pending.clone();
+                    let id = request_id.clone();
+                    tokio::spawn(async move { pending.lock().await.remove(&id) });
+                    DaemonError::Timeout(self.0.timeout)
+                })?
+                .map_err(|_| DaemonError::ReceiveFailed)?;
+
+            Ok(serde_json::from_value(value)?)
+        }
+
+        /// Breaks the recursive async cycle by boxing the future. The actual
+        /// reconnection logic lives in `reconnect_inner`.
+        fn reconnect(
+            inner: Arc<DaemonClientInner>,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), DaemonError>> + Send>>
+        {
+            Box::pin(Self::reconnect_inner(inner))
+        }
+
+        async fn reconnect_inner(inner: Arc<DaemonClientInner>) -> Result<(), DaemonError> {
+            inner.connected.send(false).ok();
+
+            // Drain all pending requests so callers get immediate ReceiveFailed
+            // instead of hanging until their individual timeouts expire.
+            {
+                let mut pending = inner.pending.lock().await;
+                for (_, sender) in pending.drain() {
+                    drop(sender);
+                }
+            }
+
+            inner.disconnect_tx.send(()).ok();
+
+            let mut attempt = 0u32;
+            let mut backoff = Duration::from_secs(1);
+            let max_backoff = Duration::from_secs(30);
+
+            loop {
+                attempt += 1;
+                let max = inner.max_reconnect_attempts.load(Ordering::Relaxed);
+                if max != u32::MAX && attempt > max {
+                    return Err(DaemonError::ReconnectFailed(max));
+                }
+
+                info!("Reconnecting to daemon (attempt {attempt})...");
+
+                match tokio_tungstenite::connect_async_tls_with_config(
+                    &inner.base_url,
+                    None,
+                    false,
+                    Some(inner.connector.clone()),
+                )
+                .await
+                {
+                    Ok((ws, _)) => {
+                        let (new_sink, new_stream) = ws.split();
+
+                        *inner.sink.lock().await = new_sink;
+
+                        // Abort old reader task if still running, then spawn a new one
+                        if let Some(handle) = inner.reader_handle.lock().await.take() {
+                            handle.abort();
+                        }
+
+                        let pending_clone = inner.pending.clone();
+                        let event_tx_clone = inner.event_tx.clone();
+                        let inner_clone = inner.clone();
+                        let new_handle = tokio::spawn(async move {
+                            if let Err(error) =
+                                handle_inbound_messages(new_stream, pending_clone, event_tx_clone)
+                                    .await
+                            {
+                                debug!("Daemon reader task ended: {error}");
+                                if let Err(e) = Self::reconnect(inner_clone).await {
+                                    error!("Reconnection failed permanently: {e}");
+                                }
+                            }
+                        });
+                        *inner.reader_handle.lock().await = Some(new_handle);
+
+                        // Re-register all subscriptions (origin is first in the vec)
+                        let subs = inner.subscriptions.lock().await.clone();
+                        for service in &subs {
+                            let request_id = next_request_id();
+                            let request = WebsocketRequest {
+                                command: "register_service".to_string(),
+                                ack: false,
+                                origin: inner.origin.clone(),
+                                destination: "daemon".to_string(),
+                                request_id,
+                                data: serde_json::json!({ "service": service }),
+                            };
+                            if let Ok(msg) = serde_json::to_string(&request) {
+                                inner
+                                    .sink
+                                    .lock()
+                                    .await
+                                    .send(tungstenite::Message::Text(msg))
+                                    .await
+                                    .ok();
+                            }
+                        }
+
+                        inner.connected.send(true).ok();
+                        inner.reconnect_tx.send(()).ok();
+
+                        info!("Reconnected to daemon successfully");
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        warn!("Reconnect attempt {attempt} failed: {e}");
+                        tokio::time::sleep(backoff).await;
+                        backoff = (backoff * 2).min(max_backoff);
+                    }
+                }
+            }
+        }
+    }
+
+    impl Clone for DaemonClient {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+
+    impl ChiaRpcClient for DaemonClient {
+        type Error = DaemonError;
+
+        fn base_url(&self) -> &str {
+            &self.0.base_url
+        }
+
+        async fn make_post_request<R, B>(&self, endpoint: &str, body: B) -> Result<R, Self::Error>
+        where
+            B: Serialize + Send,
+            R: DeserializeOwned + Send,
+        {
+            let data = serde_json::to_value(body)?;
+            self.send_request(endpoint, "chia_full_node", data).await
+        }
+    }
+
+    impl Drop for DaemonClientInner {
+        fn drop(&mut self) {
+            if let Some(handle) = self.reader_handle.get_mut().take() {
+                handle.abort();
+            }
+        }
+    }
+
+    async fn handle_inbound_messages(
+        mut stream: Stream,
+        pending: Arc<Mutex<HashMap<String, oneshot::Sender<serde_json::Value>>>>,
+        event_tx: broadcast::Sender<DaemonEvent>,
+    ) -> Result<(), DaemonError> {
+        while let Some(message) = stream.next().await {
+            let message = message?;
+
+            let text = match message {
+                tungstenite::Message::Text(text) => text,
+                tungstenite::Message::Binary(bin) => {
+                    String::from_utf8(bin).map_err(|_| DaemonError::ConnectionClosed)?
+                }
+                tungstenite::Message::Close(..) => break,
+                tungstenite::Message::Ping(..) | tungstenite::Message::Pong(..) => continue,
+                _ => continue,
+            };
+
+            let response: WebsocketResponse = match serde_json::from_str(&text) {
+                Ok(resp) => resp,
+                Err(e) => {
+                    warn!("Failed to parse daemon message: {e}");
+                    continue;
+                }
+            };
+
+            let mut pending_guard = pending.lock().await;
+            if let Some(sender) = pending_guard.remove(&response.request_id) {
+                drop(pending_guard);
+                sender.send(response.data).ok();
+            } else {
+                drop(pending_guard);
+
+                let event = DaemonEvent {
+                    command: response.command,
+                    origin: response.origin,
+                    data: response.data,
+                };
+
+                event_tx.send(event).ok();
+            }
+        }
+
+        Ok(())
+    }
 }
+
+#[cfg(any(feature = "native-tls", feature = "rustls"))]
+pub use inner::DaemonClient;

--- a/crates/chia-sdk-daemon/src/client.rs
+++ b/crates/chia-sdk-daemon/src/client.rs
@@ -1,0 +1,270 @@
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+
+use chia_sdk_coinset::ChiaRpcClient;
+use futures_util::{
+    SinkExt, StreamExt,
+    stream::{SplitSink, SplitStream},
+};
+use serde::{Serialize, de::DeserializeOwned};
+use tokio::{
+    net::TcpStream,
+    sync::{Mutex, broadcast, oneshot},
+    task::JoinHandle,
+};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+use tracing::{debug, warn};
+
+#[cfg(any(feature = "native-tls", feature = "rustls"))]
+use tokio_tungstenite::Connector;
+
+use crate::{DaemonError, DaemonEvent, WebsocketRequest, WebsocketResponse};
+
+type WebSocket = WebSocketStream<MaybeTlsStream<TcpStream>>;
+type Sink = SplitSink<WebSocket, tungstenite::Message>;
+type Stream = SplitStream<WebSocket>;
+
+static REQUEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn next_request_id() -> String {
+    REQUEST_COUNTER.fetch_add(1, Ordering::Relaxed).to_string()
+}
+
+#[derive(Debug)]
+pub struct DaemonClient(Arc<DaemonClientInner>);
+
+#[derive(Debug)]
+struct DaemonClientInner {
+    base_url: String,
+    origin: String,
+    sink: Mutex<Sink>,
+    pending: Arc<Mutex<HashMap<String, oneshot::Sender<serde_json::Value>>>>,
+    event_tx: broadcast::Sender<DaemonEvent>,
+    timeout: Duration,
+    reader_handle: JoinHandle<()>,
+}
+
+impl DaemonClient {
+    /// Connects to the Chia daemon over WSS.
+    ///
+    /// The `connector` should be built from TLS helpers in `chia-sdk-client`
+    /// (e.g. `create_native_tls_connector` or `create_rustls_connector`)
+    /// using the daemon's SSL certificate and key.
+    #[cfg(any(feature = "native-tls", feature = "rustls"))]
+    pub async fn connect(
+        url: &str,
+        connector: Connector,
+        timeout: Duration,
+    ) -> Result<Self, DaemonError> {
+        let (ws, _) =
+            tokio_tungstenite::connect_async_tls_with_config(url, None, false, Some(connector))
+                .await?;
+
+        let (sink, stream) = ws.split();
+
+        let pending: Arc<Mutex<HashMap<String, oneshot::Sender<serde_json::Value>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let (event_tx, _) = broadcast::channel::<DaemonEvent>(256);
+
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let origin = format!("chia-wallet-sdk-{nanos}");
+
+        let pending_clone = pending.clone();
+        let event_tx_clone = event_tx.clone();
+
+        let reader_handle = tokio::spawn(async move {
+            if let Err(error) = handle_inbound_messages(stream, pending_clone, event_tx_clone).await
+            {
+                debug!("Daemon reader task ended: {error}");
+            }
+        });
+
+        let client = Self(Arc::new(DaemonClientInner {
+            base_url: url.to_string(),
+            origin,
+            sink: Mutex::new(sink),
+            pending,
+            event_tx,
+            timeout,
+            reader_handle,
+        }));
+
+        client.register_service(&client.0.origin.clone()).await?;
+
+        Ok(client)
+    }
+
+    /// Returns a receiver for daemon events (e.g. metrics, state changes).
+    ///
+    /// Calling `subscribe` also sends a `register_service` command to the daemon
+    /// for the given service name, so that the daemon will forward events for
+    /// that service to this client.
+    pub async fn subscribe(
+        &self,
+        service: &str,
+    ) -> Result<broadcast::Receiver<DaemonEvent>, DaemonError> {
+        self.register_service(service).await?;
+        Ok(self.0.event_tx.subscribe())
+    }
+
+    async fn register_service(&self, service: &str) -> Result<(), DaemonError> {
+        let request_id = next_request_id();
+
+        let request = WebsocketRequest {
+            command: "register_service".to_string(),
+            ack: false,
+            origin: self.0.origin.clone(),
+            destination: "daemon".to_string(),
+            request_id,
+            data: serde_json::json!({ "service": service }),
+        };
+
+        let msg = serde_json::to_string(&request)?;
+        self.0
+            .sink
+            .lock()
+            .await
+            .send(tungstenite::Message::Text(msg))
+            .await
+            .map_err(|_| DaemonError::SendFailed)?;
+
+        Ok(())
+    }
+
+    /// Closes the websocket connection and aborts the background reader task.
+    pub async fn close(&self) -> Result<(), DaemonError> {
+        self.0.sink.lock().await.close().await?;
+        Ok(())
+    }
+
+    async fn send_request<R>(
+        &self,
+        command: &str,
+        destination: &str,
+        data: serde_json::Value,
+    ) -> Result<R, DaemonError>
+    where
+        R: DeserializeOwned + Send,
+    {
+        let request_id = next_request_id();
+
+        let request = WebsocketRequest {
+            command: command.to_string(),
+            ack: false,
+            origin: self.0.origin.clone(),
+            destination: destination.to_string(),
+            request_id: request_id.clone(),
+            data,
+        };
+
+        let (tx, rx) = oneshot::channel();
+        self.0.pending.lock().await.insert(request_id.clone(), tx);
+
+        let msg = serde_json::to_string(&request)?;
+        self.0
+            .sink
+            .lock()
+            .await
+            .send(tungstenite::Message::Text(msg))
+            .await
+            .map_err(|_| DaemonError::SendFailed)?;
+
+        let value = tokio::time::timeout(self.0.timeout, rx)
+            .await
+            .map_err(|_| {
+                // Timed out -- clean up the pending entry so the reader
+                // doesn't try to send to a closed channel later.
+                let pending = self.0.pending.clone();
+                let id = request_id.clone();
+                tokio::spawn(async move { pending.lock().await.remove(&id) });
+                DaemonError::Timeout(self.0.timeout)
+            })?
+            .map_err(|_| DaemonError::ReceiveFailed)?;
+
+        Ok(serde_json::from_value(value)?)
+    }
+}
+
+impl Clone for DaemonClient {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl ChiaRpcClient for DaemonClient {
+    type Error = DaemonError;
+
+    fn base_url(&self) -> &str {
+        &self.0.base_url
+    }
+
+    async fn make_post_request<R, B>(&self, endpoint: &str, body: B) -> Result<R, Self::Error>
+    where
+        B: Serialize + Send,
+        R: DeserializeOwned + Send,
+    {
+        let data = serde_json::to_value(body)?;
+        self.send_request(endpoint, "chia_full_node", data).await
+    }
+}
+
+impl Drop for DaemonClientInner {
+    fn drop(&mut self) {
+        self.reader_handle.abort();
+    }
+}
+
+async fn handle_inbound_messages(
+    mut stream: Stream,
+    pending: Arc<Mutex<HashMap<String, oneshot::Sender<serde_json::Value>>>>,
+    event_tx: broadcast::Sender<DaemonEvent>,
+) -> Result<(), DaemonError> {
+    while let Some(message) = stream.next().await {
+        let message = message?;
+
+        let text = match message {
+            tungstenite::Message::Text(text) => text,
+            tungstenite::Message::Binary(bin) => {
+                String::from_utf8(bin).map_err(|_| DaemonError::ConnectionClosed)?
+            }
+            tungstenite::Message::Close(..) => break,
+            tungstenite::Message::Ping(..) | tungstenite::Message::Pong(..) => continue,
+            _ => continue,
+        };
+
+        let response: WebsocketResponse = match serde_json::from_str(&text) {
+            Ok(resp) => resp,
+            Err(e) => {
+                warn!("Failed to parse daemon message: {e}");
+                continue;
+            }
+        };
+
+        let mut pending_guard = pending.lock().await;
+        if let Some(sender) = pending_guard.remove(&response.request_id) {
+            drop(pending_guard);
+            sender.send(response.data).ok();
+        } else {
+            drop(pending_guard);
+
+            let event = DaemonEvent {
+                command: response.command,
+                origin: response.origin,
+                data: response.data,
+            };
+
+            event_tx.send(event).ok();
+        }
+    }
+
+    Ok(())
+}

--- a/crates/chia-sdk-daemon/src/client.rs
+++ b/crates/chia-sdk-daemon/src/client.rs
@@ -134,8 +134,14 @@ mod inner {
 
             let client = Self(inner);
 
-            // Register own origin first, then track it for reconnection
-            client.register_service(&client.0.origin.clone()).await?;
+            // Register own origin first, then track it for reconnection.
+            // If this fails, clean up the reader task so we don't leak it.
+            if let Err(e) = client.register_service(&client.0.origin.clone()).await {
+                if let Some(handle) = client.0.reader_handle.lock().await.take() {
+                    handle.abort();
+                }
+                return Err(e);
+            }
             client
                 .0
                 .subscriptions

--- a/crates/chia-sdk-daemon/src/client.rs
+++ b/crates/chia-sdk-daemon/src/client.rs
@@ -279,7 +279,7 @@ mod inner {
         }
 
         async fn reconnect_inner(inner: Arc<DaemonClientInner>) -> Result<(), DaemonError> {
-            inner.connected.send(false).ok();
+            inner.connected.send_modify(|val| *val = false);
 
             // Drain all pending requests so callers get immediate ReceiveFailed
             // instead of hanging until their individual timeouts expire.
@@ -362,7 +362,7 @@ mod inner {
                             }
                         }
 
-                        inner.connected.send(true).ok();
+                        inner.connected.send_modify(|val| *val = true);
                         inner.reconnect_tx.send(()).ok();
 
                         info!("Reconnected to daemon successfully");

--- a/crates/chia-sdk-daemon/src/error.rs
+++ b/crates/chia-sdk-daemon/src/error.rs
@@ -19,4 +19,7 @@ pub enum DaemonError {
 
     #[error("Failed to receive response")]
     ReceiveFailed,
+
+    #[error("Reconnection failed after {0} attempts")]
+    ReconnectFailed(u32),
 }

--- a/crates/chia-sdk-daemon/src/error.rs
+++ b/crates/chia-sdk-daemon/src/error.rs
@@ -1,0 +1,22 @@
+use std::time::Duration;
+
+#[derive(Debug, thiserror::Error)]
+pub enum DaemonError {
+    #[error("WebSocket error: {0}")]
+    WebSocket(#[from] tungstenite::Error),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("Request timed out after {0:?}")]
+    Timeout(Duration),
+
+    #[error("Connection closed")]
+    ConnectionClosed,
+
+    #[error("Failed to send message")]
+    SendFailed,
+
+    #[error("Failed to receive response")]
+    ReceiveFailed,
+}

--- a/crates/chia-sdk-daemon/src/lib.rs
+++ b/crates/chia-sdk-daemon/src/lib.rs
@@ -2,6 +2,7 @@ mod client;
 mod error;
 mod types;
 
+#[cfg(any(feature = "native-tls", feature = "rustls"))]
 pub use client::*;
 pub use error::*;
 pub use types::*;

--- a/crates/chia-sdk-daemon/src/lib.rs
+++ b/crates/chia-sdk-daemon/src/lib.rs
@@ -1,0 +1,7 @@
+mod client;
+mod error;
+mod types;
+
+pub use client::*;
+pub use error::*;
+pub use types::*;

--- a/crates/chia-sdk-daemon/src/types.rs
+++ b/crates/chia-sdk-daemon/src/types.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WebsocketRequest {
+    pub command: String,
+    pub ack: bool,
+    pub origin: String,
+    pub destination: String,
+    pub request_id: String,
+    pub data: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WebsocketResponse {
+    pub command: String,
+    pub ack: bool,
+    pub origin: String,
+    pub destination: String,
+    pub request_id: String,
+    pub data: serde_json::Value,
+}
+
+#[derive(Debug, Clone)]
+pub struct DaemonEvent {
+    pub command: String,
+    pub origin: String,
+    pub data: serde_json::Value,
+}

--- a/napi/package.json
+++ b/napi/package.json
@@ -46,6 +46,8 @@
   "ava": {
     "timeout": "3m",
     "cache": false,
+    "verbose": true,
+    "workerThreads": false,
     "extensions": [
       "ts"
     ],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod prelude;
 
 pub use chia_sdk_client as client;
 pub use chia_sdk_coinset as coinset;
+pub use chia_sdk_daemon as daemon;
 pub use chia_sdk_driver as driver;
 pub use chia_sdk_signer as signer;
 pub use chia_sdk_test as test;


### PR DESCRIPTION
## Summary

New `chia-sdk-daemon` crate that connects to the Chia daemon over WSS, enabling two capabilities that weren't previously possible with the HTTP-only RPC clients:

- **RPC calls routed through the daemon** - implements the `ChiaRpcClient` trait from `chia-sdk-coinset`, so all existing full node RPC methods (`get_blockchain_state`, `get_block_record`, `push_tx`, etc.) work transparently over the daemon's websocket connection. No new API to learn.
- **Real-time event subscriptions** - subscribe to daemon event streams like `metrics` to receive push notifications for blocks, signage points, and other chain events as they happen, without polling.

### Why

The existing `CoinsetClient` and `FullNodeClient` are HTTP-only, which means the only way to detect new blocks or signage points is to poll. For applications that need to react to chain events in real time, polling introduces unnecessary latency and load.

The Chia daemon already exposes a websocket interface that pushes events to subscribers. `chia-sdk-daemon` brings that same capability to Rust consumers, with an API that reuses the existing `ChiaRpcClient` trait for RPC and adds a simple `subscribe()` method for events.

### Why a separate crate

The existing `CoinsetClient` and `FullNodeClient` in `chia-sdk-coinset` are stateless HTTP clients with a lean dependency footprint (`reqwest`, `serde`, `hex`). The daemon websocket client is fundamentally different - it maintains a persistent connection with a background reader task, reconnection logic, broadcast channels, and requires `tokio-tungstenite`, `futures-util`, and `tracing`. Keeping it separate means:

- Consumers who only need HTTP RPC don't pull in the websocket/tokio dependency tree
- `chia-sdk-coinset` stays wasm-compatible; the daemon client is inherently non-wasm
- The reconnection and event subscription complexity lives in its own maintenance surface

The crate is re-exported from the root as `chia_wallet_sdk::daemon`, and the `native-tls`/`rustls` feature flags flow through automatically, so consumers of the umbrella crate get it without any extra setup.

### Features

- Sync request/response RPC via the daemon websocket (all `ChiaRpcClient` methods)
- Event subscriptions via `tokio::sync::broadcast` channels
- Automatic reconnection with exponential backoff on connection loss
- Subscription re-registration after reconnect
- Connection lifecycle hooks (`on_disconnect`, `on_reconnect`)
- Configurable reconnection retry limits
- TLS support via `native-tls` or `rustls` feature flags (mirrors `chia-sdk-client`)

### Usage

```rust
let cert = load_ssl_cert("~/.chia/.../private_daemon.crt", "~/.chia/.../private_daemon.key")?;
let connector = create_rustls_connector(&cert)?;
let client = DaemonClient::connect("wss://localhost:55400", connector, Duration::from_secs(10)).await?;

// RPC - same trait as CoinsetClient / FullNodeClient
let state = client.get_blockchain_state().await?;

// Event subscription
let mut events = client.subscribe("metrics").await?;
while let Ok(event) = events.recv().await {
    if event.command == "block" {
        // react to new block
    }
}