### PR TITLE
CI: fix Windows AVA EPERM flake, use public ARM64 runners, bump actions

### DIFF
--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -47,7 +47,7 @@ jobs:
           - host: macos-latest
             target: aarch64-apple-darwin
             build: pnpm build:macos-arm64
-          - host: linux-arm64
+          - host: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             docker: quay.io/pypa/manylinux_2_28_aarch64
             build: |
@@ -249,7 +249,7 @@ jobs:
           - "20"
           - "22"
           - "24"
-    runs-on: linux-arm64
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -62,14 +62,14 @@ jobs:
     name: stable - ${{ matrix.settings.target }} - node@24
     runs-on: ${{ matrix.settings.host }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 9
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         if: ${{ !matrix.settings.docker }}
         with:
           node-version: 24
@@ -84,7 +84,7 @@ jobs:
           targets: ${{ matrix.settings.target }}
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry/index/
@@ -125,7 +125,7 @@ jobs:
         shell: bash
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bindings-${{ matrix.settings.target }}
           path: napi/${{ env.APP_NAME }}.*.node
@@ -152,14 +152,14 @@ jobs:
           - "24"
     runs-on: ${{ matrix.settings.host }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 9
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
@@ -170,7 +170,7 @@ jobs:
         run: pnpm install
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bindings-${{ matrix.settings.target }}
           path: napi
@@ -198,14 +198,14 @@ jobs:
           - "24"
     runs-on: ubuntu-latest
     steps:
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 9
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
@@ -215,7 +215,7 @@ jobs:
         run: pnpm install
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bindings-x86_64-unknown-linux-gnu
           path: napi
@@ -251,14 +251,14 @@ jobs:
           - "24"
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 9
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
@@ -268,7 +268,7 @@ jobs:
         run: pnpm install
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bindings-aarch64-unknown-linux-gnu
           path: napi
@@ -297,14 +297,14 @@ jobs:
         working-directory: ./napi
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 9
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -314,13 +314,13 @@ jobs:
         run: pnpm install
 
       - name: Download macOS x64 artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bindings-x86_64-apple-darwin
           path: napi
 
       - name: Download macOS arm64 artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bindings-aarch64-apple-darwin
           path: napi
@@ -329,7 +329,7 @@ jobs:
         run: pnpm universal
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bindings-universal-apple-darwin
           path: napi/${{ env.APP_NAME }}.*.node
@@ -347,14 +347,14 @@ jobs:
       run:
         working-directory: ./napi
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 9
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -364,7 +364,7 @@ jobs:
         run: pnpm install
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: napi/artifacts
 

--- a/.github/workflows/pyo3.yml
+++ b/.github/workflows/pyo3.yml
@@ -33,8 +33,8 @@ jobs:
           - runner: ubuntu-24.04-arm
             target: aarch64
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
       - name: Build wheels
@@ -62,7 +62,7 @@ jobs:
                 apt update -y && apt-get install -y libssl-dev openssl pkg-config
             fi
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-linux-${{ matrix.platform.target }}
           path: pyo3/dist
@@ -77,8 +77,8 @@ jobs:
           - runner: ubuntu-24.04-arm
             target: aarch64
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
       - name: Build wheels
@@ -92,7 +92,7 @@ jobs:
           manylinux: musllinux_1_2
           working-directory: pyo3
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-musllinux-${{ matrix.platform.target }}
           path: pyo3/dist
@@ -105,8 +105,8 @@ jobs:
           - runner: windows-latest
             target: x64
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
           architecture: ${{ matrix.platform.target }}
@@ -118,7 +118,7 @@ jobs:
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           working-directory: pyo3
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-windows-${{ matrix.platform.target }}
           path: pyo3/dist
@@ -133,8 +133,8 @@ jobs:
           - runner: macos-14
             target: aarch64
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
       - name: Build wheels
@@ -145,7 +145,7 @@ jobs:
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           working-directory: pyo3
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-macos-${{ matrix.platform.target }}
           path: pyo3/dist
@@ -153,8 +153,8 @@ jobs:
   sdist:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
 
@@ -174,7 +174,7 @@ jobs:
           rm -rf $dirname
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-sdist
           path: pyo3/dist
@@ -185,8 +185,8 @@ jobs:
       run:
         working-directory: ./pyo3
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
 
@@ -203,7 +203,7 @@ jobs:
   stubs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -229,9 +229,9 @@ jobs:
       # Used to generate artifact attestation
       attestations: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest@v4
         with:
           subject-path: "wheels-*/*"
       - name: Publish to PyPI

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cargo binstall
         run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -26,14 +26,14 @@ jobs:
       run:
         working-directory: ./wasm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 9
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -59,7 +59,7 @@ jobs:
           wasm-pack pack
 
       - name: Upload NPM pkg artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: npm-pkg
           path: ./wasm/pkg/*-*.tgz

--- a/napi/package.json
+++ b/napi/package.json
@@ -52,7 +52,7 @@
       "ts"
     ],
     "require": [
-      "ts-node/register"
+      "./register-ts-node.cjs"
     ]
   }
 }

--- a/napi/register-ts-node.cjs
+++ b/napi/register-ts-node.cjs
@@ -1,0 +1,12 @@
+// Loading `ts-node/register` directly via AVA's `require` config causes every
+// test worker to fall through AVA's `loadRequiredModule` into `importFromProject`,
+// which races to `writeFileAtomic` the shared
+// `node_modules/.cache/ava/import-from-project.mjs` stub. On Windows that
+// concurrent rename fails intermittently with:
+//   EPERM: operation not permitted, rename '...import-from-project.mjs.<pid>' -> '...import-from-project.mjs'
+// (see npm/write-file-atomic#28 / #227).
+//
+// Pointing AVA at this file (a real path relative to projectDir) makes
+// `require(fullPath)` succeed on the first try, so AVA never writes the
+// stub and the race goes away.
+require("ts-node/register");


### PR DESCRIPTION
- Fix Windows AVA test flake caused by concurrent `write-file-atomic`
  rename on `node_modules/.cache/ava/import-from-project.mjs`
- Switch aarch64-unknown-linux-gnu build/test jobs from the private
  `linux-arm64` label to GitHub's free `ubuntu-24.04-arm` hosted runner
- Bump `actions/checkout`, `actions/setup-node`, `actions/cache`,
  `actions/{upload,download}-artifact`, and `pnpm/action-setup`
  across all four workflows to silence deprecated Node 20 runner warnings