### PR TITLE
Add support for offer pre-split in clear signing

### DIFF
--- a/crates/chia-sdk-driver/src/clear_signing/children.rs
+++ b/crates/chia-sdk-driver/src/clear_signing/children.rs
@@ -1,18 +1,38 @@
-use chia_protocol::Coin;
+use chia_protocol::{Bytes32, Coin};
+use chia_puzzles::SETTLEMENT_PAYMENT_HASH;
 use chia_sdk_types::Condition;
 use clvmr::Allocator;
 
 use crate::{
-    Cat, DriverError, Facts, Nft, ParsedAsset, ParsedMemos, RevealedCoinSpend, parse_memos,
+    BURN_PUZZLE_HASH, Cat, DriverError, Facts, Nft, ParsedAsset, ParsedMemos, RevealedCoinSpend,
+    RevealedP2Puzzle, Reveals, parse_memos,
 };
 
 #[derive(Debug, Clone)]
 pub struct ParsedChild {
     pub asset: ParsedAsset,
     pub memos: ParsedMemos,
+    pub transfer_type: TransferType,
+}
+
+#[derive(Debug, Clone)]
+pub enum TransferType {
+    Sent,
+    Burned,
+    Offered,
+    OfferPreSplit(OfferPreSplitInfo),
+}
+
+#[derive(Debug, Clone)]
+pub struct OfferPreSplitInfo {
+    pub launcher_id: Bytes32,
+    pub nonce: usize,
+    pub fixed_conditions: Vec<Condition>,
+    pub settlement_amount: u64,
 }
 
 pub fn parse_children(
+    reveals: &Reveals,
     facts: &mut Facts,
     allocator: &mut Allocator,
     asset: &ParsedAsset,
@@ -59,13 +79,17 @@ pub fn parse_children(
                 match &asset {
                     // All XCH children are considered to be XCH by default.
                     ParsedAsset::Xch(_) => {
+                        let memos = parse_memos(allocator, *condition, false);
+                        let transfer_type = calculate_transfer_type(reveals, &memos);
+
                         children.push(ParsedChild {
                             asset: ParsedAsset::Xch(Coin::new(
                                 spend.coin.coin_id(),
                                 condition.puzzle_hash,
                                 condition.amount,
                             )),
-                            memos: parse_memos(allocator, *condition, false),
+                            memos,
+                            transfer_type,
                         });
                     }
                     // For NFTs, even amount children are XCH coins. If the amount is odd, it's the
@@ -82,18 +106,26 @@ pub fn parse_children(
                                 return Err(DriverError::MissingChild);
                             };
 
+                            let memos = parse_memos(allocator, *condition, true);
+                            let transfer_type = calculate_transfer_type(reveals, &memos);
+
                             children.push(ParsedChild {
                                 asset: ParsedAsset::Nft(nft),
-                                memos: parse_memos(allocator, *condition, true),
+                                memos,
+                                transfer_type,
                             });
                         } else {
+                            let memos = parse_memos(allocator, *condition, false);
+                            let transfer_type = calculate_transfer_type(reveals, &memos);
+
                             children.push(ParsedChild {
                                 asset: ParsedAsset::Xch(Coin::new(
                                     spend.coin.coin_id(),
                                     condition.puzzle_hash,
                                     condition.amount,
                                 )),
-                                memos: parse_memos(allocator, *condition, false),
+                                memos,
+                                transfer_type,
                             });
                         }
                     }
@@ -109,9 +141,13 @@ pub fn parse_children(
                             return Err(DriverError::RevocableChild);
                         }
 
+                        let memos = parse_memos(allocator, *condition, true);
+                        let transfer_type = calculate_transfer_type(reveals, &memos);
+
                         children.push(ParsedChild {
                             asset: ParsedAsset::Cat(cat),
-                            memos: parse_memos(allocator, *condition, true),
+                            memos,
+                            transfer_type,
                         });
                     }
                 }
@@ -121,4 +157,34 @@ pub fn parse_children(
     }
 
     Ok(children)
+}
+
+fn calculate_transfer_type(reveals: &Reveals, memos: &ParsedMemos) -> TransferType {
+    if memos.p2_puzzle_hash == BURN_PUZZLE_HASH {
+        TransferType::Burned
+    } else if memos.p2_puzzle_hash == SETTLEMENT_PAYMENT_HASH.into() {
+        TransferType::Offered
+    } else if memos.clawback.is_none()
+        && let Some(RevealedP2Puzzle::P2ConditionsOrSingleton(p2_puzzle)) =
+            reveals.p2_puzzle(memos.p2_puzzle_hash.into())
+    {
+        let mut settlement_amount = 0;
+
+        for condition in &p2_puzzle.fixed_conditions {
+            if let Some(condition) = condition.as_create_coin()
+                && condition.puzzle_hash == SETTLEMENT_PAYMENT_HASH.into()
+            {
+                settlement_amount += condition.amount;
+            }
+        }
+
+        TransferType::OfferPreSplit(OfferPreSplitInfo {
+            launcher_id: p2_puzzle.launcher_id,
+            nonce: p2_puzzle.nonce,
+            fixed_conditions: p2_puzzle.fixed_conditions.clone(),
+            settlement_amount,
+        })
+    } else {
+        TransferType::Sent
+    }
 }

--- a/crates/chia-sdk-driver/src/clear_signing/reveals.rs
+++ b/crates/chia-sdk-driver/src/clear_signing/reveals.rs
@@ -33,7 +33,7 @@ pub struct RevealedCoinSpend {
     pub solution: NodePtr,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct Reveals {
     coin_spends: IndexMap<Bytes32, RevealedCoinSpend>,
     p2_puzzles: HashMap<TreeHash, RevealedP2Puzzle>,
@@ -42,22 +42,31 @@ pub struct Reveals {
     vault_nonces: HashSet<usize>,
 }
 
+impl Default for Reveals {
+    fn default() -> Self {
+        let mut vault_nonces = HashSet::new();
+
+        vault_nonces.insert(0);
+
+        Self {
+            coin_spends: IndexMap::new(),
+            p2_puzzles: HashMap::new(),
+            requested_payments: RequestedPayments::default(),
+            asset_info: AssetInfo::default(),
+            vault_nonces,
+        }
+    }
+}
+
 impl Reveals {
-    pub fn from_spends(
+    pub fn from_coin_spends(
         allocator: &mut Allocator,
-        coin_spends: Vec<CoinSpend>,
-        spent_clawbacks: Vec<ClawbackV2>,
+        coin_spends: &[CoinSpend],
     ) -> Result<Self, DriverError> {
         let mut reveals = Self::default();
 
-        reveals.reveal_vault_nonce(0);
-
         for coin_spend in coin_spends {
-            reveals.reveal_coin_spend(allocator, &coin_spend)?;
-        }
-
-        for clawback in spent_clawbacks {
-            reveals.reveal_clawback(clawback);
+            reveals.reveal_coin_spend(allocator, coin_spend)?;
         }
 
         Ok(reveals)

--- a/crates/chia-sdk-driver/src/clear_signing/tests.rs
+++ b/crates/chia-sdk-driver/src/clear_signing/tests.rs
@@ -12,7 +12,7 @@ use rstest::rstest;
 
 use crate::{
     Action, BURN_PUZZLE_HASH, Cat, CatInfo, CatSpend, CustodyInfo, Deltas, DropCoin, FeeAction, Id,
-    IssuanceKind, Nft, ParsedAsset, Spend, SpendContext, Spends, TestVault, VaultOutput,
+    IssuanceKind, Nft, ParsedAsset, Reveals, Spend, SpendContext, Spends, TestVault, VaultOutput,
     parse_vault_transaction,
 };
 
@@ -110,7 +110,8 @@ fn test_clear_signing_vault_child() -> Result<()> {
 
     let result = alice.spend(&mut sim, &mut ctx, &[])?;
 
-    let tx = parse_vault_transaction(&mut ctx, result.delegated_spend, result.coin_spends, vec![])?;
+    let reveals = Reveals::from_coin_spends(&mut ctx, &result.coin_spends)?;
+    let tx = parse_vault_transaction(&reveals, &mut ctx, result.delegated_spend)?;
 
     assert_eq!(
         tx.vault_child,
@@ -138,7 +139,8 @@ fn test_clear_signing_vault_info() -> Result<()> {
         &[Action::send(Id::Xch, alice.p2_puzzle_hash, 1, Memos::None)],
     )?;
 
-    let tx = parse_vault_transaction(&mut ctx, result.delegated_spend, result.coin_spends, vec![])?;
+    let reveals = Reveals::from_coin_spends(&mut ctx, &result.coin_spends)?;
+    let tx = parse_vault_transaction(&reveals, &mut ctx, result.delegated_spend)?;
 
     // Because we spent another coin, we know the launcher id and p2 puzzle hashes.
     assert_eq!(tx.launcher_id, Some(alice.info.launcher_id));
@@ -159,7 +161,8 @@ fn test_clear_signing_drop_coins() -> Result<()> {
     let vault_conditions = Conditions::new().create_coin(Bytes32::default(), 0, Memos::None);
     let result = alice.custom_spend(&mut sim, &mut ctx, &[], spends, vault_conditions)?;
 
-    let tx = parse_vault_transaction(&mut ctx, result.delegated_spend, result.coin_spends, vec![])?;
+    let reveals = Reveals::from_coin_spends(&mut ctx, &result.coin_spends)?;
+    let tx = parse_vault_transaction(&reveals, &mut ctx, result.delegated_spend)?;
 
     assert_eq!(tx.spends.len(), 0);
     assert_eq!(tx.drop_coins, [DropCoin::new(Bytes32::default(), 0)]);
@@ -195,7 +198,8 @@ fn test_clear_signing_reserved_fee(#[case] fee_paid: u64, #[case] reserved_fee: 
         ],
     )?;
 
-    let tx = parse_vault_transaction(&mut ctx, result.delegated_spend, result.coin_spends, vec![])?;
+    let reveals = Reveals::from_coin_spends(&mut ctx, &result.coin_spends)?;
+    let tx = parse_vault_transaction(&reveals, &mut ctx, result.delegated_spend)?;
 
     assert_eq!(tx.fee_paid, fee_paid);
     assert_eq!(tx.reserved_fee, reserved_fee);
@@ -226,7 +230,8 @@ fn test_clear_signing_self_transfer(
         &[Action::send(id, alice.p2_puzzle_hash, 42, memos)],
     )?;
 
-    let tx = parse_vault_transaction(&mut ctx, result.delegated_spend, result.coin_spends, vec![])?;
+    let reveals = Reveals::from_coin_spends(&mut ctx, &result.coin_spends)?;
+    let tx = parse_vault_transaction(&reveals, &mut ctx, result.delegated_spend)?;
 
     assert_eq!(tx.spends.len(), 1);
 
@@ -269,7 +274,8 @@ fn test_clear_signing_intermediate_p2_singleton() -> Result<()> {
         ],
     )?;
 
-    let tx = parse_vault_transaction(&mut ctx, result.delegated_spend, result.coin_spends, vec![])?;
+    let reveals = Reveals::from_coin_spends(&mut ctx, &result.coin_spends)?;
+    let tx = parse_vault_transaction(&reveals, &mut ctx, result.delegated_spend)?;
 
     assert_eq!(tx.spends.len(), 2);
 
@@ -338,7 +344,8 @@ fn test_clear_signing_intermediate_delegated_conditions(
 
     let result = alice.custom_spend(&mut sim, &mut ctx, &actions, spends, Conditions::new())?;
 
-    let tx = parse_vault_transaction(&mut ctx, result.delegated_spend, result.coin_spends, vec![])?;
+    let reveals = Reveals::from_coin_spends(&mut ctx, &result.coin_spends)?;
+    let tx = parse_vault_transaction(&reveals, &mut ctx, result.delegated_spend)?;
 
     assert_eq!(tx.spends.len(), if asserted { 2 } else { 1 });
 
@@ -418,7 +425,8 @@ fn test_clear_signing_chained_delegated_conditions(
 
     let result = alice.custom_spend(&mut sim, &mut ctx, &actions, spends, Conditions::new())?;
 
-    let tx = parse_vault_transaction(&mut ctx, result.delegated_spend, result.coin_spends, vec![])?;
+    let reveals = Reveals::from_coin_spends(&mut ctx, &result.coin_spends)?;
+    let tx = parse_vault_transaction(&reveals, &mut ctx, result.delegated_spend)?;
 
     assert_eq!(
         tx.spends.len(),
@@ -497,7 +505,8 @@ fn test_clear_signing_transfer(
         ],
     )?;
 
-    let tx = parse_vault_transaction(&mut ctx, result.delegated_spend, result.coin_spends, vec![])?;
+    let reveals = Reveals::from_coin_spends(&mut ctx, &result.coin_spends)?;
+    let tx = parse_vault_transaction(&reveals, &mut ctx, result.delegated_spend)?;
 
     assert_eq!(tx.fee_paid, fee);
     assert_eq!(tx.reserved_fee, fee);
@@ -530,7 +539,8 @@ fn test_clear_signing_mint_nft() -> Result<()> {
 
     let result = alice.spend(&mut sim, &mut ctx, &[Action::mint_empty_nft()])?;
 
-    let tx = parse_vault_transaction(&mut ctx, result.delegated_spend, result.coin_spends, vec![])?;
+    let reveals = Reveals::from_coin_spends(&mut ctx, &result.coin_spends)?;
+    let tx = parse_vault_transaction(&reveals, &mut ctx, result.delegated_spend)?;
 
     assert_eq!(tx.spends.len(), 2);
 
@@ -560,7 +570,8 @@ fn test_clear_signing_transfer_nft() -> Result<()> {
     let alice = TestVault::mint(&mut sim, &mut ctx, 1)?;
 
     let result = alice.spend(&mut sim, &mut ctx, &[Action::mint_empty_nft()])?;
-    let tx = parse_vault_transaction(&mut ctx, result.delegated_spend, result.coin_spends, vec![])?;
+    let reveals = Reveals::from_coin_spends(&mut ctx, &result.coin_spends)?;
+    let tx = parse_vault_transaction(&reveals, &mut ctx, result.delegated_spend)?;
     let nft = unwrap_nft(&tx.spends[1].children[0].asset);
 
     let hint = ctx.hint(BURN_PUZZLE_HASH)?;
@@ -574,7 +585,8 @@ fn test_clear_signing_transfer_nft() -> Result<()> {
             hint,
         )],
     )?;
-    let tx = parse_vault_transaction(&mut ctx, result.delegated_spend, result.coin_spends, vec![])?;
+    let reveals = Reveals::from_coin_spends(&mut ctx, &result.coin_spends)?;
+    let tx = parse_vault_transaction(&reveals, &mut ctx, result.delegated_spend)?;
 
     assert_eq!(tx.spends.len(), 1);
 
@@ -615,7 +627,8 @@ fn test_clear_signing_p2_singleton_cat_issuance(
         )],
     )?;
 
-    let tx = parse_vault_transaction(&mut ctx, result.delegated_spend, result.coin_spends, vec![])?;
+    let reveals = Reveals::from_coin_spends(&mut ctx, &result.coin_spends)?;
+    let tx = parse_vault_transaction(&reveals, &mut ctx, result.delegated_spend)?;
 
     assert_eq!(tx.issuances.len(), 1);
 
@@ -695,7 +708,8 @@ fn test_clear_signing_delegated_conditions_cat_issuance() -> Result<()> {
 
     let result = alice.custom_spend(&mut sim, &mut ctx, &actions, spends, Conditions::new())?;
 
-    let tx = parse_vault_transaction(&mut ctx, result.delegated_spend, result.coin_spends, vec![])?;
+    let reveals = Reveals::from_coin_spends(&mut ctx, &result.coin_spends)?;
+    let tx = parse_vault_transaction(&reveals, &mut ctx, result.delegated_spend)?;
 
     assert_eq!(tx.issuances.len(), 1);
 

--- a/crates/chia-sdk-driver/src/clear_signing/vault_transaction.rs
+++ b/crates/chia-sdk-driver/src/clear_signing/vault_transaction.rs
@@ -1,7 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
-use chia_protocol::{Bytes32, CoinSpend};
+use chia_protocol::Bytes32;
 use chia_puzzle_types::cat::CatSolution;
+use chia_puzzles::SETTLEMENT_PAYMENT_HASH;
 use chia_sdk_types::{Condition, Mod, puzzles::SingletonMember};
 use clvm_traits::{FromClvm, ToClvm, clvm_quote};
 use clvm_utils::tree_hash;
@@ -9,9 +10,9 @@ use clvmr::{Allocator, NodePtr};
 use indexmap::{IndexMap, IndexSet};
 
 use crate::{
-    AssertedRequestedPayment, ClawbackInfo, ClawbackV2, CustodyInfo, DriverError, DropCoin, Facts,
-    Issuance, IssuanceKind, P2ConditionsOrSingletonInfo, P2SingletonInfo, ParsedAsset, ParsedChild,
-    ParsedSpend, Reveals, Spend, VaultMessage, VaultOutput, get_extra_delta_message,
+    AssertedRequestedPayment, ClawbackInfo, CustodyInfo, DriverError, DropCoin, Facts, Issuance,
+    IssuanceKind, P2ConditionsOrSingletonInfo, P2SingletonInfo, ParsedAsset, ParsedChild,
+    ParsedSpend, Reveals, Spend, TransferType, VaultMessage, VaultOutput, get_extra_delta_message,
     mips_puzzle_hash, parse_asserted_requested_payments, parse_children, parse_run_cat_tail,
     parse_spend, parse_vault_delegated_spend,
 };
@@ -37,6 +38,12 @@ pub struct VaultTransaction {
     /// Requested payments which were both revealed and asserted by the vault spend. These are assets which are going
     /// to be received when and if the transaction is confirmed on-chain.
     pub received_payments: Vec<AssertedRequestedPayment>,
+    /// If this transaction creates one or more offer pre-split coins, this rolls them up into a
+    /// description of the future offer. Per-leg details (the individual pre-split amounts) live
+    /// in the children's transfer type field.
+    ///
+    /// [`None`] means the transaction does not link any offer pre-split coins.
+    pub linked_offer: Option<LinkedOffer>,
     /// Total fees (different between input and output amounts) paid by coin spends authorized by the vault.
     /// If the transaction is signed, the fee is guaranteed to be at least this amount, unless it's not reserved.
     /// The reason to include unreserved fees is to make it clear that the XCH is leaving the vault due to this transaction.
@@ -62,21 +69,25 @@ pub struct VerifiedSpend {
     pub children: Vec<ParsedChild>,
 }
 
+#[derive(Debug, Clone)]
+pub struct LinkedOffer {
+    pub reserved_fee: u64,
+    pub requested_payments: Vec<AssertedRequestedPayment>,
+}
+
 pub fn parse_vault_transaction(
+    reveals: &Reveals,
     allocator: &mut Allocator,
     delegated_spend: Spend,
-    coin_spends: Vec<CoinSpend>,
-    spent_clawbacks: Vec<ClawbackV2>,
 ) -> Result<VaultTransaction, DriverError> {
     let mut facts = Facts::default();
 
-    let reveals = Reveals::from_spends(allocator, coin_spends, spent_clawbacks)?;
     let vault_spend = parse_vault_delegated_spend(&mut facts, allocator, delegated_spend)?;
 
     let mut parsed_spends = HashMap::new();
 
     for spend in reveals.coin_spends() {
-        let parsed_spend = parse_spend(&reveals, allocator, spend)?;
+        let parsed_spend = parse_spend(reveals, allocator, spend)?;
         parsed_spends.insert(spend.coin.coin_id(), parsed_spend);
     }
 
@@ -93,7 +104,7 @@ pub fn parse_vault_transaction(
 
     for (coin_id, messages) in messages_by_coin {
         let verified_spend = verify_spend(
-            &reveals,
+            reveals,
             &mut facts,
             allocator,
             &mut parsed_spends,
@@ -121,7 +132,7 @@ pub fn parse_vault_transaction(
         }
 
         let verified_spend = verify_spend(
-            &reveals,
+            reveals,
             &mut facts,
             allocator,
             &mut parsed_spends,
@@ -164,13 +175,15 @@ pub fn parse_vault_transaction(
     }
 
     let fee_paid = (input_amount - output_amount).try_into()?;
-    let received_payments = parse_asserted_requested_payments(&reveals, &facts, allocator)?;
+    let received_payments = parse_asserted_requested_payments(reveals, &facts, allocator)?;
     let launcher_id = find_launcher_id(&verified_spends)?;
     let p2_puzzle_hashes = if let Some(launcher_id) = launcher_id {
-        calculate_p2_puzzle_hashes(&reveals, launcher_id)
+        calculate_p2_puzzle_hashes(reveals, launcher_id)
     } else {
         Vec::new()
     };
+
+    let linked_offer = build_linked_offer(reveals, allocator, &verified_spends, launcher_id)?;
 
     Ok(VaultTransaction {
         vault_child: vault_spend.child,
@@ -178,6 +191,7 @@ pub fn parse_vault_transaction(
         spends: verified_spends,
         issuances,
         received_payments,
+        linked_offer,
         fee_paid,
         reserved_fee,
         launcher_id,
@@ -280,6 +294,7 @@ fn verify_spend(
     }
 
     let children = parse_children(
+        reveals,
         facts,
         allocator,
         &parsed_spend.asset,
@@ -345,4 +360,79 @@ fn calculate_p2_puzzle_hashes(reveals: &Reveals, launcher_id: Bytes32) -> Vec<By
     }
 
     p2_puzzle_hashes
+}
+
+fn build_linked_offer(
+    reveals: &Reveals,
+    allocator: &Allocator,
+    spends: &[VerifiedSpend],
+    expected_launcher_id: Option<Bytes32>,
+) -> Result<Option<LinkedOffer>, DriverError> {
+    let mut linked_offer = LinkedOffer {
+        reserved_fee: 0,
+        requested_payments: vec![],
+    };
+    let mut has_offer = false;
+    let mut found_puzzle_assertions = None;
+
+    for spend in spends {
+        for child in &spend.children {
+            let TransferType::OfferPreSplit(info) = &child.transfer_type else {
+                continue;
+            };
+
+            has_offer = true;
+
+            if expected_launcher_id != Some(info.launcher_id) {
+                return Err(DriverError::WrongLinkedOfferLauncherId);
+            }
+
+            let mut reserved_fee = 0;
+            let mut puzzle_assertions = HashSet::new();
+
+            for condition in &info.fixed_conditions {
+                match condition {
+                    Condition::CreateCoin(condition) => {
+                        if condition.puzzle_hash != SETTLEMENT_PAYMENT_HASH.into() {
+                            return Err(DriverError::InvalidLinkedOfferPayment);
+                        }
+                    }
+                    Condition::ReserveFee(condition) => {
+                        reserved_fee += condition.amount;
+                    }
+                    Condition::AssertPuzzleAnnouncement(condition) => {
+                        puzzle_assertions.insert(condition.announcement_id);
+                    }
+                    _ => {}
+                }
+            }
+
+            if child.asset.coin().amount != info.settlement_amount + reserved_fee {
+                return Err(DriverError::WrongOfferPreSplitOutput);
+            }
+
+            linked_offer.reserved_fee += reserved_fee;
+
+            if let Some(found_puzzle_assertions) = &found_puzzle_assertions {
+                if found_puzzle_assertions != &puzzle_assertions {
+                    return Err(DriverError::ConflictingLinkedOfferPuzzleAssertions);
+                }
+            } else {
+                found_puzzle_assertions = Some(puzzle_assertions);
+            }
+        }
+    }
+
+    if let Some(found_puzzle_assertions) = found_puzzle_assertions {
+        let mut offer_facts = Facts::default();
+
+        for announcement_id in found_puzzle_assertions {
+            offer_facts.assert_puzzle_announcement(announcement_id);
+        }
+
+        linked_offer.requested_payments =
+            parse_asserted_requested_payments(reveals, &offer_facts, allocator)?;
+    }
+
+    Ok(has_offer.then_some(linked_offer))
 }

--- a/crates/chia-sdk-driver/src/driver_error.rs
+++ b/crates/chia-sdk-driver/src/driver_error.rs
@@ -163,4 +163,16 @@ pub enum DriverError {
 
     #[error("multiple vault messages matched the same custody slot")]
     DuplicateVaultMessage,
+
+    #[error("wrong linked offer launcher id")]
+    WrongLinkedOfferLauncherId,
+
+    #[error("linked offer coin creates non-settlement payment")]
+    InvalidLinkedOfferPayment,
+
+    #[error("offer pre-split coin has the wrong output amount")]
+    WrongOfferPreSplitOutput,
+
+    #[error("conflicting puzzle assertions in linked offer")]
+    ConflictingLinkedOfferPuzzleAssertions,
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0e210d0c9f0d2085f1372a82ebe4907d9f83cb45. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->