### PR TITLE
Add CHIP-0037 puzzle scaffolding (p2_eip712_message, p2_controller_puzzle)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rstest 0.22.0",
+ "sha3",
  "thiserror 2.0.17",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ workspace = true
 
 [features]
 chip-0035 = ["chia-sdk-driver/chip-0035", "chia-sdk-types/chip-0035"]
+chip-0037 = ["chia-sdk-driver/chip-0037", "chia-sdk-types/chip-0037"]
 offer-compression = ["chia-sdk-driver/offer-compression"]
 native-tls = ["chia-sdk-client/native-tls", "chia-sdk-coinset/native-tls", "chia-sdk-daemon/native-tls"]
 rustls = ["chia-sdk-client/rustls", "chia-sdk-coinset/rustls", "chia-sdk-daemon/rustls"]
@@ -175,6 +176,7 @@ wasm-bindgen-futures = "0.4.50"
 wasm-bindgen-derive = "0.3.0"
 getrandom = "0.3.4"
 sha2 = "0.10.9"
+sha3 = "0.10.8"
 pyo3 = "0.23.5"
 js-sys = "0.3.77"
 parking_lot = "0.12.5"

--- a/crates/chia-sdk-driver/Cargo.toml
+++ b/crates/chia-sdk-driver/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 
 [features]
 chip-0035 = ["chia-sdk-types/chip-0035"]
+chip-0037 = ["chia-sdk-types/chip-0037", "dep:sha3"]
 action-layer = ["chia-sdk-types/action-layer"]
 offer-compression = ["dep:flate2", "dep:chia-sdk-utils"]
 
@@ -43,6 +44,7 @@ bigdecimal = { workspace = true }
 chia-sdk-utils = { workspace = true, optional = true }
 chia-traits = {workspace = true }
 flate2 = { workspace = true, features = ["zlib-ng-compat"], optional = true }
+sha3 = { workspace = true, optional = true }
 indexmap = { workspace = true }
 chia_streamable_macro = { workspace = true }
 rand = { workspace = true }

--- a/crates/chia-sdk-driver/src/layers.rs
+++ b/crates/chia-sdk-driver/src/layers.rs
@@ -40,6 +40,16 @@ mod datalayer;
 #[cfg(feature = "chip-0035")]
 pub use datalayer::*;
 
+#[cfg(feature = "chip-0037")]
+mod p2_controller_puzzle_layer;
+#[cfg(feature = "chip-0037")]
+mod p2_eip712_message_layer;
+
+#[cfg(feature = "chip-0037")]
+pub use p2_controller_puzzle_layer::*;
+#[cfg(feature = "chip-0037")]
+pub use p2_eip712_message_layer::*;
+
 #[cfg(feature = "action-layer")]
 mod action_layer;
 

--- a/crates/chia-sdk-driver/src/layers/p2_controller_puzzle_layer.rs
+++ b/crates/chia-sdk-driver/src/layers/p2_controller_puzzle_layer.rs
@@ -1,0 +1,152 @@
+use chia_protocol::Bytes32;
+use chia_sdk_types::puzzles::{
+    P2_CONTROLLER_PUZZLE_PUZZLE_HASH, P2ControllerPuzzleArgs, P2ControllerPuzzleSolution,
+};
+use clvm_traits::FromClvm;
+use clvmr::{Allocator, NodePtr};
+
+use crate::{DriverError, Layer, Puzzle, Spend, SpendContext};
+
+/// The CHIP-0037 controller-puzzle [`Layer`].
+///
+/// Locks a coin so it can only be spent when a coin whose puzzle hash equals
+/// `controller_puzzle_hash` sends a `RECEIVE_MESSAGE` whose body is the tree
+/// hash of the chosen `delegated_puzzle`. Useful for collapsing many
+/// per-coin signatures into a single signature on the controller (for example
+/// a [`P2Eip712MessageLayer`](super::P2Eip712MessageLayer) coin).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct P2ControllerPuzzleLayer {
+    pub controller_puzzle_hash: Bytes32,
+}
+
+impl P2ControllerPuzzleLayer {
+    pub fn new(controller_puzzle_hash: Bytes32) -> Self {
+        Self {
+            controller_puzzle_hash,
+        }
+    }
+
+    /// Spend a coin locked by this layer with a `delegated_spend` previously
+    /// authorised by the controller coin.
+    pub fn spend(
+        &self,
+        ctx: &mut SpendContext,
+        delegated_spend: Spend,
+    ) -> Result<Spend, DriverError> {
+        self.construct_spend(
+            ctx,
+            P2ControllerPuzzleSolution {
+                delegated_puzzle: delegated_spend.puzzle,
+                delegated_solution: delegated_spend.solution,
+            },
+        )
+    }
+}
+
+impl Layer for P2ControllerPuzzleLayer {
+    type Solution = P2ControllerPuzzleSolution<NodePtr, NodePtr>;
+
+    fn parse_puzzle(allocator: &Allocator, puzzle: Puzzle) -> Result<Option<Self>, DriverError> {
+        let Some(puzzle) = puzzle.as_curried() else {
+            return Ok(None);
+        };
+
+        if puzzle.mod_hash != P2_CONTROLLER_PUZZLE_PUZZLE_HASH {
+            return Ok(None);
+        }
+
+        let args = P2ControllerPuzzleArgs::from_clvm(allocator, puzzle.args)?;
+
+        Ok(Some(Self {
+            controller_puzzle_hash: args.controller_puzzle_hash,
+        }))
+    }
+
+    fn parse_solution(
+        allocator: &Allocator,
+        solution: NodePtr,
+    ) -> Result<Self::Solution, DriverError> {
+        Ok(P2ControllerPuzzleSolution::from_clvm(allocator, solution)?)
+    }
+
+    fn construct_puzzle(&self, ctx: &mut SpendContext) -> Result<NodePtr, DriverError> {
+        ctx.curry(P2ControllerPuzzleArgs {
+            controller_puzzle_hash: self.controller_puzzle_hash,
+        })
+    }
+
+    fn construct_solution(
+        &self,
+        ctx: &mut SpendContext,
+        solution: Self::Solution,
+    ) -> Result<NodePtr, DriverError> {
+        ctx.alloc(&solution)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use chia_protocol::Bytes;
+    use chia_sdk_test::Simulator;
+    use chia_sdk_types::{Conditions, conditions::SendMessage};
+    use clvm_traits::{ToClvm, clvm_quote};
+
+    /// A controller coin spend authorising a delegated puzzle for one
+    /// controlled coin succeeds, demonstrating the one-message-many-spends
+    /// workflow described in CHIP-0037.
+    #[test]
+    fn test_p2_controller_puzzle() -> anyhow::Result<()> {
+        let mut sim = Simulator::new();
+        let mut ctx = SpendContext::new();
+        let ctx = &mut ctx;
+
+        // The controller is a degenerate quoted-conditions coin so that we can
+        // emit any conditions we want to test the message-routing semantics.
+        let controller_puzzle = ctx.one();
+        let controller_puzzle_hash: Bytes32 = ctx.tree_hash(controller_puzzle).into();
+
+        let layer = P2ControllerPuzzleLayer::new(controller_puzzle_hash);
+        let coin_puzzle = layer.construct_puzzle(ctx)?;
+        let coin_puzzle_hash = ctx.tree_hash(coin_puzzle);
+
+        let controller_coin = sim.new_coin(controller_puzzle_hash, 42);
+        let coin = sim.new_coin(coin_puzzle_hash.into(), 69);
+
+        let delegated_puzzle =
+            clvm_quote!(Conditions::new().reserve_fee(42 + 69)).to_clvm(&mut **ctx)?;
+        let delegated_solution = ctx.nil();
+
+        let delegated_puzzle_hash: Bytes32 = ctx.tree_hash(delegated_puzzle).into();
+
+        let coin_spend = layer.construct_coin_spend(
+            ctx,
+            coin,
+            P2ControllerPuzzleSolution {
+                delegated_puzzle,
+                delegated_solution,
+            },
+        )?;
+        ctx.insert(coin_spend);
+
+        // mode 0b010111 == puzzle hash → coin
+        let coin_id_ptr = ctx.alloc(&coin.coin_id())?;
+        let controller_solution = vec![SendMessage::new(
+            23,
+            Bytes::new(delegated_puzzle_hash.to_vec()),
+            vec![coin_id_ptr],
+        )]
+        .to_clvm(&mut **ctx)?;
+
+        let controller_spend = chia_protocol::CoinSpend::new(
+            controller_coin,
+            chia_protocol::Program::from_clvm(&**ctx, controller_puzzle)?,
+            chia_protocol::Program::from_clvm(&**ctx, controller_solution)?,
+        );
+        ctx.insert(controller_spend);
+
+        sim.spend_coins(ctx.take(), &[])?;
+        Ok(())
+    }
+}

--- a/crates/chia-sdk-driver/src/layers/p2_eip712_message_layer.rs
+++ b/crates/chia-sdk-driver/src/layers/p2_eip712_message_layer.rs
@@ -238,7 +238,6 @@ mod tests {
     #[test]
     fn test_softfork_cost() -> anyhow::Result<()> {
         let mut ctx = SpendContext::new();
-        let ctx = &mut ctx;
         // Equivalent CLVM source:
         //   (mod (PREFIX_AND_DOMAIN_SEPARATOR TYPE_HASH my_id delegated_puzzle_hash signed_hash)
         //     (if (= (keccak256 PREFIX_AND_DOMAIN_SEPARATOR
@@ -246,7 +245,7 @@ mod tests {
         //            signed_hash) () (x)))
         let puzzle_bytes =
             hex!("ff02ffff03ffff09ffff3eff02ffff3eff05ff0bff178080ff2f80ff80ffff01ff088080ff0180");
-        let puzzle_ptr = node_from_bytes(&mut **ctx, puzzle_bytes.as_slice())?;
+        let puzzle_ptr = node_from_bytes(&mut ctx, puzzle_bytes.as_slice())?;
         let solution_ptr = vec![
             // PREFIX_AND_DOMAIN_SEPARATOR (testnet/mainnet-independent fixture)
             Bytes::new(
@@ -270,10 +269,10 @@ mod tests {
                 hex!("9f61fdf6077c3eeb96eaa4dd450b11ba3ae17746a2c304388218137972c7ba4c").to_vec(),
             ),
         ]
-        .to_clvm(&mut **ctx)?;
+        .to_clvm(&mut *ctx)?;
 
         let Reduction(cost, _) = clvmr::run_program(
-            &mut **ctx,
+            &mut ctx,
             &clvmr::ChiaDialect::new(ENABLE_KECCAK_OPS_OUTSIDE_GUARD),
             puzzle_ptr,
             solution_ptr,
@@ -338,8 +337,7 @@ mod tests {
         } else {
             let err = sim
                 .spend_coins(ctx.take(), &[])
-                .err()
-                .expect("spend should fail when signed_hash is wrong");
+                .expect_err("spend should fail when signed_hash is wrong");
             let msg = err.to_string();
             assert!(
                 msg.contains("clvm raise") || msg.to_lowercase().contains("raise"),

--- a/crates/chia-sdk-driver/src/layers/p2_eip712_message_layer.rs
+++ b/crates/chia-sdk-driver/src/layers/p2_eip712_message_layer.rs
@@ -1,0 +1,352 @@
+use chia_protocol::Bytes32;
+use chia_sdk_types::puzzles::{
+    Eip712PrefixAndDomainSeparator, P2_EIP712_MESSAGE_PUZZLE_HASH, P2Eip712MessageArgs,
+    P2Eip712MessageSolution,
+};
+use chia_secp::{K1PublicKey, K1Signature};
+use clvm_traits::FromClvm;
+use clvmr::{Allocator, NodePtr};
+use sha3::{Digest, Keccak256};
+
+use crate::{DriverError, Layer, Puzzle, Spend, SpendContext};
+
+/// The CHIP-0037 EIP-712 message [`Layer`].
+///
+/// Allows a coin to be controlled by an Ethereum-style wallet that signs an
+/// EIP-712 typed-data message of type `ChiaCoinSpend(bytes32 coin_id, bytes32
+/// delegated_puzzle_hash)`. The puzzle reconstructs the EIP-712 digest from
+/// the signed envelope (`\x19\x01 || domainSeparator || keccak256(typeHash ||
+/// coin_id || delegated_puzzle_hash)`) inside a `softfork` guard so the spend
+/// is bound to this exact coin and chosen `delegated_puzzle`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct P2Eip712MessageLayer {
+    pub prefix_and_domain_separator: Eip712PrefixAndDomainSeparator,
+    pub public_key: K1PublicKey,
+}
+
+impl P2Eip712MessageLayer {
+    pub fn new(
+        public_key: K1PublicKey,
+        prefix_and_domain_separator: Eip712PrefixAndDomainSeparator,
+    ) -> Self {
+        Self {
+            prefix_and_domain_separator,
+            public_key,
+        }
+    }
+
+    /// Convenience constructor that derives the prefix-and-domain-separator
+    /// from a network's genesis challenge.
+    pub fn from_genesis_challenge(public_key: K1PublicKey, genesis_challenge: Bytes32) -> Self {
+        Self {
+            prefix_and_domain_separator: Self::prefix_and_domain_separator(genesis_challenge),
+            public_key,
+        }
+    }
+
+    /// Compute the EIP-712 domain separator for the given Chia network.
+    ///
+    /// Domain matches the schema mandated by CHIP-0037:
+    /// `{ name: "Chia Coin Spend", version: "1", salt: <genesis_challenge> }`.
+    pub fn domain_separator(genesis_challenge: Bytes32) -> Bytes32 {
+        let type_hash = Keccak256::digest(b"EIP712Domain(string name,string version,bytes32 salt)");
+
+        let mut to_hash = Vec::new();
+        to_hash.extend_from_slice(&type_hash);
+        to_hash.extend_from_slice(&Keccak256::digest(b"Chia Coin Spend"));
+        to_hash.extend_from_slice(&Keccak256::digest(b"1"));
+        to_hash.extend_from_slice(&genesis_challenge);
+
+        Bytes32::new(Keccak256::digest(&to_hash).into())
+    }
+
+    /// Compute the 34-byte concatenation of the EIP-712 prefix (`\x19\x01`)
+    /// and the domain separator for a given network.
+    pub fn prefix_and_domain_separator(
+        genesis_challenge: Bytes32,
+    ) -> Eip712PrefixAndDomainSeparator {
+        let mut bytes = [0u8; 34];
+        bytes[0] = 0x19;
+        bytes[1] = 0x01;
+        bytes[2..].copy_from_slice(&Self::domain_separator(genesis_challenge));
+        bytes.into()
+    }
+
+    /// Keccak-256 hash of the canonical CHIP-0037 EIP-712 type signature.
+    pub fn type_hash() -> Bytes32 {
+        Bytes32::new(
+            Keccak256::digest(b"ChiaCoinSpend(bytes32 coin_id,bytes32 delegated_puzzle_hash)")
+                .into(),
+        )
+    }
+
+    /// Compute the 32-byte EIP-712 digest the off-chain wallet must sign.
+    ///
+    /// `digest = keccak256(prefix_and_domain || keccak256(type_hash || coin_id
+    /// || delegated_puzzle_hash))`
+    pub fn hash_to_sign(&self, coin_id: Bytes32, delegated_puzzle_hash: Bytes32) -> Bytes32 {
+        let mut to_hash = Vec::with_capacity(96);
+        to_hash.extend_from_slice(&Self::type_hash());
+        to_hash.extend_from_slice(&coin_id);
+        to_hash.extend_from_slice(&delegated_puzzle_hash);
+        let message_hash = Keccak256::digest(&to_hash);
+
+        let mut to_hash = Vec::with_capacity(34 + 32);
+        to_hash.extend_from_slice(&self.prefix_and_domain_separator);
+        to_hash.extend_from_slice(&message_hash);
+
+        Bytes32::new(Keccak256::digest(&to_hash).into())
+    }
+
+    /// Construct a `Spend` for a coin locked by this layer using a previously
+    /// obtained signature over `hash_to_sign(coin_id, tree_hash(delegated))`.
+    pub fn spend(
+        &self,
+        ctx: &mut SpendContext,
+        my_id: Bytes32,
+        signature: K1Signature,
+        delegated_spend: Spend,
+    ) -> Result<Spend, DriverError> {
+        let signed_hash = self.hash_to_sign(my_id, ctx.tree_hash(delegated_spend.puzzle).into());
+        self.construct_spend(
+            ctx,
+            P2Eip712MessageSolution {
+                my_id,
+                signed_hash,
+                signature,
+                delegated_puzzle: delegated_spend.puzzle,
+                delegated_solution: delegated_spend.solution,
+            },
+        )
+    }
+}
+
+impl Layer for P2Eip712MessageLayer {
+    type Solution = P2Eip712MessageSolution<NodePtr, NodePtr>;
+
+    fn parse_puzzle(allocator: &Allocator, puzzle: Puzzle) -> Result<Option<Self>, DriverError> {
+        let Some(puzzle) = puzzle.as_curried() else {
+            return Ok(None);
+        };
+
+        if puzzle.mod_hash != P2_EIP712_MESSAGE_PUZZLE_HASH {
+            return Ok(None);
+        }
+
+        let args = P2Eip712MessageArgs::from_clvm(allocator, puzzle.args)?;
+
+        if args.type_hash != Self::type_hash() {
+            return Ok(None);
+        }
+
+        Ok(Some(Self {
+            prefix_and_domain_separator: args.prefix_and_domain_separator,
+            public_key: args.public_key,
+        }))
+    }
+
+    fn parse_solution(
+        allocator: &Allocator,
+        solution: NodePtr,
+    ) -> Result<Self::Solution, DriverError> {
+        Ok(P2Eip712MessageSolution::from_clvm(allocator, solution)?)
+    }
+
+    fn construct_puzzle(&self, ctx: &mut SpendContext) -> Result<NodePtr, DriverError> {
+        ctx.curry(P2Eip712MessageArgs {
+            prefix_and_domain_separator: self.prefix_and_domain_separator,
+            type_hash: Self::type_hash(),
+            public_key: self.public_key,
+        })
+    }
+
+    fn construct_solution(
+        &self,
+        ctx: &mut SpendContext,
+        solution: Self::Solution,
+    ) -> Result<NodePtr, DriverError> {
+        ctx.alloc(&solution)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use chia_consensus::consensus_constants::TEST_CONSTANTS;
+    use chia_protocol::Bytes;
+    use chia_sdk_test::Simulator;
+    use chia_sdk_types::Conditions;
+    use chia_secp::K1SecretKey;
+    use clvm_traits::{ToClvm, clvm_quote};
+    use clvm_utils::ToTreeHash;
+    use clvmr::chia_dialect::ENABLE_KECCAK_OPS_OUTSIDE_GUARD;
+    use clvmr::reduction::Reduction;
+    use clvmr::serde::node_from_bytes;
+    use hex_literal::hex;
+    use rand::{Rng, SeedableRng};
+    use rand_chacha::ChaCha8Rng;
+    use rstest::rstest;
+
+    fn k1_pair(seed: u64) -> (K1SecretKey, K1PublicKey) {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let sk = K1SecretKey::from_bytes(&rng.random()).unwrap();
+        let pk = sk.public_key();
+        (sk, pk)
+    }
+
+    #[test]
+    fn test_type_hash() {
+        assert_eq!(
+            P2Eip712MessageLayer::type_hash(),
+            Bytes32::new(hex!(
+                "72930978f119c79f9de7a13bd50c9b3261132d7b4819bdf0d3ca4d4c37ade070"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_domain_separator_is_deterministic() {
+        // Two invocations with the same genesis challenge must produce the
+        // same domain separator (the value itself depends on which network
+        // `TEST_CONSTANTS` currently models).
+        let a = P2Eip712MessageLayer::domain_separator(TEST_CONSTANTS.genesis_challenge);
+        let b = P2Eip712MessageLayer::domain_separator(TEST_CONSTANTS.genesis_challenge);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_domain_separator_mainnet_fixture() {
+        // Mainnet genesis challenge per chia-blockchain/initial-config.yaml.
+        let mainnet_genesis = Bytes32::new(hex!(
+            "ccd5bb71183532bff220ba46c268991a3ff07eb358e8255a65c30a2dce0e5fbb"
+        ));
+        // Pinned digest produced by the canonical EIP-712 algorithm
+        // (`keccak256(typeHash || keccak256("Chia Coin Spend") ||
+        // keccak256("1") || mainnet_genesis)`); regenerate this if upstream
+        // ever changes the EIP-712 schema.
+        assert_eq!(
+            P2Eip712MessageLayer::domain_separator(mainnet_genesis),
+            Bytes32::new(hex!(
+                "38d765d3bce341eed11f92fc1311d575f34cc9ee0fc0e1f03820e11aebf6b5b2"
+            ))
+        );
+    }
+
+    /// Pin the cost of the keccak256-reconstruction sub-puzzle that runs inside
+    /// the `softfork` guard. CHIP-0037 fixes this at exactly 2605 cost.
+    #[test]
+    fn test_softfork_cost() -> anyhow::Result<()> {
+        let mut ctx = SpendContext::new();
+        let ctx = &mut ctx;
+        // Equivalent CLVM source:
+        //   (mod (PREFIX_AND_DOMAIN_SEPARATOR TYPE_HASH my_id delegated_puzzle_hash signed_hash)
+        //     (if (= (keccak256 PREFIX_AND_DOMAIN_SEPARATOR
+        //                       (keccak256 TYPE_HASH my_id delegated_puzzle_hash))
+        //            signed_hash) () (x)))
+        let puzzle_bytes =
+            hex!("ff02ffff03ffff09ffff3eff02ffff3eff05ff0bff178080ff2f80ff80ffff01ff088080ff0180");
+        let puzzle_ptr = node_from_bytes(&mut **ctx, puzzle_bytes.as_slice())?;
+        let solution_ptr = vec![
+            // PREFIX_AND_DOMAIN_SEPARATOR (testnet/mainnet-independent fixture)
+            Bytes::new(
+                hex!("1901098ccd7d09a29365582c3f7590712bc2c2eb8503586f8a4c628c61c73ffbe4aa")
+                    .to_vec(),
+            ),
+            // TYPE_HASH
+            Bytes::new(
+                hex!("72930978f119c79f9de7a13bd50c9b3261132d7b4819bdf0d3ca4d4c37ade070").to_vec(),
+            ),
+            // my_id
+            Bytes::new(
+                hex!("5c777c45fd52a17a54e420742cadc56172847d9a106ff0ff8af38ef757d84829").to_vec(),
+            ),
+            // delegated_puzzle_hash
+            Bytes::new(
+                hex!("d842dfa1453a130a8be66bc32708a2d1884662d7daaa4aae530be3259fa6712f").to_vec(),
+            ),
+            // signed_hash
+            Bytes::new(
+                hex!("9f61fdf6077c3eeb96eaa4dd450b11ba3ae17746a2c304388218137972c7ba4c").to_vec(),
+            ),
+        ]
+        .to_clvm(&mut **ctx)?;
+
+        let Reduction(cost, _) = clvmr::run_program(
+            &mut **ctx,
+            &clvmr::ChiaDialect::new(ENABLE_KECCAK_OPS_OUTSIDE_GUARD),
+            puzzle_ptr,
+            solution_ptr,
+            11_000_000_000,
+        )?;
+
+        assert_eq!(cost, 2605);
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::successful_spend(true)]
+    #[case::incorrect_signed_hash(false)]
+    fn test_p2_eip712_message(#[case] correct_signed_hash: bool) -> anyhow::Result<()> {
+        let (sk, pk) = k1_pair(0xC0DE_F00D);
+
+        let mut sim = Simulator::new();
+        let mut ctx = SpendContext::new();
+        let ctx = &mut ctx;
+
+        let layer =
+            P2Eip712MessageLayer::from_genesis_challenge(pk, TEST_CONSTANTS.genesis_challenge);
+        let coin_puzzle_reveal = layer.construct_puzzle(ctx)?;
+        let coin_puzzle_hash = ctx.tree_hash(coin_puzzle_reveal);
+
+        let coin = sim.new_coin(coin_puzzle_hash.into(), 1337);
+
+        let delegated_puzzle_ptr =
+            clvm_quote!(Conditions::new().reserve_fee(1337)).to_clvm(&mut **ctx)?;
+        let delegated_solution_ptr = ctx.nil();
+
+        // For the negative case we substitute a digest the wallet would never
+        // produce for this spend, so the on-chain reconstruction check fails.
+        let signed_hash: Bytes32 = if correct_signed_hash {
+            layer.hash_to_sign(coin.coin_id(), ctx.tree_hash(delegated_puzzle_ptr).into())
+        } else {
+            layer
+                .hash_to_sign(coin.coin_id(), ctx.tree_hash(delegated_puzzle_ptr).into())
+                .tree_hash()
+                .into()
+        };
+
+        let signed_hash_bytes: [u8; 32] = signed_hash.into();
+        let signature = sk.sign_prehashed(&signed_hash_bytes)?;
+
+        let coin_spend = layer.construct_coin_spend(
+            ctx,
+            coin,
+            P2Eip712MessageSolution {
+                my_id: coin.coin_id(),
+                signed_hash,
+                signature,
+                delegated_puzzle: delegated_puzzle_ptr,
+                delegated_solution: delegated_solution_ptr,
+            },
+        )?;
+
+        ctx.insert(coin_spend);
+
+        if correct_signed_hash {
+            sim.spend_coins(ctx.take(), &[])?;
+        } else {
+            let err = sim
+                .spend_coins(ctx.take(), &[])
+                .err()
+                .expect("spend should fail when signed_hash is wrong");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("clvm raise") || msg.to_lowercase().contains("raise"),
+                "unexpected error: {msg}"
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/crates/chia-sdk-types/Cargo.toml
+++ b/crates/chia-sdk-types/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 
 [features]
 chip-0035 = []
+chip-0037 = []
 action-layer = []
 
 [dependencies]

--- a/crates/chia-sdk-types/src/puzzles.rs
+++ b/crates/chia-sdk-types/src/puzzles.rs
@@ -26,6 +26,16 @@ mod datalayer;
 #[cfg(feature = "chip-0035")]
 pub use datalayer::*;
 
+#[cfg(feature = "chip-0037")]
+mod p2_controller_puzzle;
+#[cfg(feature = "chip-0037")]
+mod p2_eip712_message;
+
+#[cfg(feature = "chip-0037")]
+pub use p2_controller_puzzle::*;
+#[cfg(feature = "chip-0037")]
+pub use p2_eip712_message::*;
+
 #[cfg(feature = "action-layer")]
 mod action_layer;
 

--- a/crates/chia-sdk-types/src/puzzles/p2_controller_puzzle.rs
+++ b/crates/chia-sdk-types/src/puzzles/p2_controller_puzzle.rs
@@ -1,0 +1,86 @@
+use std::borrow::Cow;
+
+use chia_protocol::Bytes32;
+use clvm_traits::{FromClvm, ToClvm};
+use clvm_utils::TreeHash;
+use hex_literal::hex;
+
+use crate::Mod;
+
+/// Curried arguments for the CHIP-0037 controller puzzle.
+///
+/// A coin locked by this puzzle can only be spent when a coin whose puzzle
+/// hash equals `controller_puzzle_hash` sends a `RECEIVE_MESSAGE` whose body
+/// is the tree hash of the chosen `delegated_puzzle`. This collapses many
+/// coin-spending signatures into one (e.g. one EIP-712 prompt unlocks many
+/// downstream coins).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[clvm(curry)]
+pub struct P2ControllerPuzzleArgs {
+    pub controller_puzzle_hash: Bytes32,
+}
+
+impl P2ControllerPuzzleArgs {
+    pub fn new(controller_puzzle_hash: Bytes32) -> Self {
+        Self {
+            controller_puzzle_hash,
+        }
+    }
+}
+
+impl Mod for P2ControllerPuzzleArgs {
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&P2_CONTROLLER_PUZZLE_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        P2_CONTROLLER_PUZZLE_PUZZLE_HASH
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[clvm(list)]
+pub struct P2ControllerPuzzleSolution<P, S> {
+    pub delegated_puzzle: P,
+    pub delegated_solution: S,
+}
+
+impl<P, S> P2ControllerPuzzleSolution<P, S> {
+    pub fn new(delegated_puzzle: P, delegated_solution: S) -> Self {
+        Self {
+            delegated_puzzle,
+            delegated_solution,
+        }
+    }
+}
+
+/// CLVM bytecode for the CHIP-0037 `p2_controller_puzzle` puzzle.
+///
+/// Source: <https://github.com/Chia-Network/chips/blob/main/assets/chip-0037/clsp/p2_controller_puzzle.clsp>
+pub const P2_CONTROLLER_PUZZLE_PUZZLE: [u8; 151] = hex!(
+    "
+    ff02ffff01ff04ffff04ff04ffff04ffff0117ffff04ffff02ff06ffff04ff02
+    ffff04ff0bff80808080ffff04ff05ff8080808080ffff02ff0bff178080ffff
+    04ffff01ff43ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ff
+    ff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080
+    808080ffff01ff0bffff0101ff058080ff0180ff018080
+    "
+);
+
+pub const P2_CONTROLLER_PUZZLE_PUZZLE_HASH: TreeHash = TreeHash::new(hex!(
+    "d5415713619e318bfa7820e06e2b163beef32d82294a5a7fcf9c3c69b0949c88"
+));
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::assert_puzzle_hash;
+
+    #[test]
+    fn test_puzzle_hash() -> anyhow::Result<()> {
+        assert_puzzle_hash!(P2_CONTROLLER_PUZZLE_PUZZLE => P2_CONTROLLER_PUZZLE_PUZZLE_HASH);
+
+        Ok(())
+    }
+}

--- a/crates/chia-sdk-types/src/puzzles/p2_eip712_message.rs
+++ b/crates/chia-sdk-types/src/puzzles/p2_eip712_message.rs
@@ -1,0 +1,118 @@
+use std::borrow::Cow;
+
+use chia_protocol::{Bytes32, BytesImpl};
+use chia_secp::{K1PublicKey, K1Signature};
+use clvm_traits::{FromClvm, ToClvm};
+use clvm_utils::TreeHash;
+use hex_literal::hex;
+
+use crate::Mod;
+
+/// The 2-byte EIP-712 envelope prefix (`\x19\x01`) followed by the 32-byte
+/// EIP-712 domain separator computed for the target Chia network.
+///
+/// Currying these two values together (instead of as separate atoms) saves a
+/// `concat` inside the softfork guard and matches the on-chain layout used by
+/// the puzzle when reconstructing the EIP-712 digest.
+pub type Eip712PrefixAndDomainSeparator = BytesImpl<34>;
+
+/// Curried arguments for the EIP-712 message puzzle (CHIP-0037).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[clvm(curry)]
+pub struct P2Eip712MessageArgs {
+    pub prefix_and_domain_separator: Eip712PrefixAndDomainSeparator,
+    pub type_hash: Bytes32,
+    pub public_key: K1PublicKey,
+}
+
+impl P2Eip712MessageArgs {
+    pub fn new(
+        prefix_and_domain_separator: Eip712PrefixAndDomainSeparator,
+        type_hash: Bytes32,
+        public_key: K1PublicKey,
+    ) -> Self {
+        Self {
+            prefix_and_domain_separator,
+            type_hash,
+            public_key,
+        }
+    }
+}
+
+impl Mod for P2Eip712MessageArgs {
+    fn mod_reveal() -> Cow<'static, [u8]> {
+        Cow::Borrowed(&P2_EIP712_MESSAGE_PUZZLE)
+    }
+
+    fn mod_hash() -> TreeHash {
+        P2_EIP712_MESSAGE_PUZZLE_HASH
+    }
+}
+
+/// Solution for the EIP-712 message puzzle.
+///
+/// `signed_hash` is the EIP-712 digest the off-chain wallet committed to; the
+/// puzzle independently reconstructs the digest from `my_id` and the tree hash
+/// of `delegated_puzzle` to ensure the signature is bound to this exact spend.
+#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[clvm(list)]
+pub struct P2Eip712MessageSolution<P, S> {
+    pub my_id: Bytes32,
+    pub signed_hash: Bytes32,
+    pub signature: K1Signature,
+    pub delegated_puzzle: P,
+    pub delegated_solution: S,
+}
+
+impl<P, S> P2Eip712MessageSolution<P, S> {
+    pub fn new(
+        my_id: Bytes32,
+        signed_hash: Bytes32,
+        signature: K1Signature,
+        delegated_puzzle: P,
+        delegated_solution: S,
+    ) -> Self {
+        Self {
+            my_id,
+            signed_hash,
+            signature,
+            delegated_puzzle,
+            delegated_solution,
+        }
+    }
+}
+
+/// CLVM bytecode for the CHIP-0037 `p2_eip712_message` puzzle.
+///
+/// Source: <https://github.com/Chia-Network/chips/blob/main/assets/chip-0037/clsp/p2_eip712_message.clsp>
+pub const P2_EIP712_MESSAGE_PUZZLE: [u8; 276] = hex!(
+    "
+    ff02ffff01ff02ffff03ffff22ffff20ffff8413d61f00ff17ff5fff81bf8080
+    ffff20ffff24ffff01820ab9ffff0101ffff01ff02ffff03ffff09ffff3eff02
+    ffff3eff05ff0bff178080ff2f80ff80ffff01ff088080ff0180ffff04ff05ff
+    ff04ff0bffff04ff2fffff04ffff02ff06ffff04ff02ffff04ff82017fff8080
+    8080ffff04ff5fff808080808080808080ffff01ff04ffff04ff04ffff04ff2f
+    ff808080ffff02ff82017fff8202ff8080ffff01ff088080ff0180ffff04ffff
+    01ff46ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ffff04ff
+    02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080808080
+    ffff01ff0bffff0101ff058080ff0180ff018080
+    "
+);
+
+pub const P2_EIP712_MESSAGE_PUZZLE_HASH: TreeHash = TreeHash::new(hex!(
+    "aacce7b99db5b1e9eb16d676fa5f1a2e469ef589f29c4ab0010bac338a4df085"
+));
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::assert_puzzle_hash;
+
+    #[test]
+    fn test_puzzle_hash() -> anyhow::Result<()> {
+        assert_puzzle_hash!(P2_EIP712_MESSAGE_PUZZLE => P2_EIP712_MESSAGE_PUZZLE_HASH);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

Ports the two [CHIP-0037](https://github.com/Chia-Network/chips/blob/main/CHIPs/chip-0037.md) puzzles (`p2_eip712_message` and `p2_controller_puzzle`) onto current `main` as scaffolding behind a new `chip-0037` feature flag. Mirrors the existing `chip-0035` (DataLayer) feature-gating pattern.

This is deliberately scaffolding only: it lands the puzzle bytecode, args/solution types, `Mod` impls, `Layer` impls, and a focused test suite. WASM/napi bindings, MIPS `Eip712Member` integration, and any consumer-side glue are intentionally out of scope and will follow as separate atomic PRs.

The work picks up where [#124](https://github.com/xch-dev/chia-wallet-sdk/pull/124) left off but rebased onto current `main` and reworked to follow conventions that have stabilised since #124 was opened (~520 commits ago).

## What's in the diff

| Crate | File | Purpose |
|---|---|---|
| `chia-sdk-types` | `puzzles/p2_eip712_message.rs` | `P2Eip712MessageArgs` / `P2Eip712MessageSolution<P, S>` + puzzle bytecode + `Mod` impl |
| `chia-sdk-types` | `puzzles/p2_controller_puzzle.rs` | `P2ControllerPuzzleArgs` / `P2ControllerPuzzleSolution<P, S>` + puzzle bytecode + `Mod` impl |
| `chia-sdk-driver` | `layers/p2_eip712_message_layer.rs` | `P2Eip712MessageLayer` with `domain_separator`, `prefix_and_domain_separator`, `type_hash`, `hash_to_sign`, `spend`, full `Layer` impl |
| `chia-sdk-driver` | `layers/p2_controller_puzzle_layer.rs` | `P2ControllerPuzzleLayer` with `Layer` impl + `spend` helper |
| `Cargo.toml` (workspace) | — | New `chip-0037` feature aggregator + `sha3 = "0.10.8"` workspace dep |
| `chia-sdk-types/Cargo.toml` | — | `chip-0037 = []` |
| `chia-sdk-driver/Cargo.toml` | — | `chip-0037 = ["chia-sdk-types/chip-0037", "dep:sha3"]` + optional `sha3` |

10 files, +738 / -0.

## Convention compliance

- Uses `chia_secp::K1PublicKey` / `K1Signature` rather than `BytesImpl<33>` / `BytesImpl<64>`, matching the rest of the MIPS member types (`K1Member`, `R1Member`, etc.).
- Puzzle constants live in `chia-sdk-types::puzzles` (not the driver), matching `p2_curried`, `p2_singleton`, etc.
- Layer code uses `ctx.curry(args)` rather than constructing `CurriedProgram` manually.
- Both puzzles implement the `Mod` trait so they participate in `ctx.alloc_mod` / `curry_tree_hash` like every other puzzle.
- `#[clvm(curry)]` for args, `#[clvm(list)]` for solutions.
- Module wiring is feature-gated identically to `chip-0035` in `puzzles.rs` and `layers.rs`.
- No changes outside the `chip-0037` feature; default builds are byte-identical.

## Tests (`cargo test -p chia-sdk-driver --features chip-0037`)

```
test layers::p2_eip712_message_layer::tests::test_type_hash ... ok
test layers::p2_eip712_message_layer::tests::test_softfork_cost ... ok
test layers::p2_eip712_message_layer::tests::test_domain_separator_is_deterministic ... ok
test layers::p2_eip712_message_layer::tests::test_domain_separator_mainnet_fixture ... ok
test layers::p2_eip712_message_layer::tests::test_p2_eip712_message::case_1_successful_spend ... ok
test layers::p2_eip712_message_layer::tests::test_p2_eip712_message::case_2_incorrect_signed_hash ... ok
test layers::p2_controller_puzzle_layer::tests::test_p2_controller_puzzle ... ok
... plus the existing 4 layer tests (cat, p2_singleton, standard, etc.) all still pass.
```

Plus the puzzle-hash sanity tests in `chia-sdk-types`:

```
test puzzles::p2_eip712_message::tests::test_puzzle_hash ... ok
test puzzles::p2_controller_puzzle::tests::test_puzzle_hash ... ok
```

Notable validations:

- `P2_EIP712_MESSAGE_PUZZLE_HASH` = `aacce7b9...df085`, matches the [CHIP-0037 reference asset](https://github.com/Chia-Network/chips/blob/main/assets/chip-0037).
- `P2_CONTROLLER_PUZZLE_PUZZLE_HASH` = `d5415713...49c88`, ditto.
- EIP-712 type hash for `ChiaCoinSpend(bytes32 coin_id,bytes32 delegated_puzzle_hash)` = `72930978...ade070`.
- The keccak256-reconstruction sub-puzzle running inside the `softfork` guard costs **exactly 2605** (matches the spec's pinned cost).
- End-to-end: a `secp256k1_verify` over a `k256` ECDSA signature over the EIP-712 digest is accepted by the simulator, and a tampered `signed_hash` is correctly rejected with `clvm raise`.

## Why CHIP-0037

EIP-712 typed-data signatures let any wallet that already speaks Ethereum signing semantics (MetaMask, hardware wallets via WalletConnect, custodian APIs, etc.) directly authorise Chia coin spends. No BLS keys are required on the signer side. The Chia side stays fully on-chain by reconstructing the EIP-712 digest inside a `softfork` guard and validating the signature with `secp256k1_verify` (CHIP-0011) and `keccak256` (CHIP-0036).

The controller-puzzle adjunct lets a single signature on a controlling coin authorise many controlled coins to spend with a chosen delegated puzzle, useful for batched operations and for compositions on top of MIPS / DID / vault primitives.

## Follow-ups (separate PRs)

- Add `Eip712Member` as a CHIP-0043 MIPS member type so it composes with `m_of_n`, restrictions, and the existing delegated-puzzle wrappers without needing a parallel quorum puzzle.
- WASM (`wasm-bindgen`) and napi bindings exposing `P2Eip712MessageLayer::{from_genesis_challenge, hash_to_sign, type_hash}` so off-chain wallets can compute the digest to sign.
- Optional: a `puzzles_clvm/p2_eip712_message.clsp` source-of-truth file under whatever the repo's preferred home for puzzle source ends up being. (None of the existing puzzles in `chia-sdk-types::puzzles` ship `.clsp`; happy to follow whatever convention the maintainers prefer.)

## Provenance

- Original puzzle bytecode and EIP-712 schema: [Yakuhito's hermes](https://github.com/Yakuhito/hermes) and the canonical CHIP-0037 reference assets.
- Original SDK PR concept: [#124](https://github.com/xch-dev/chia-wallet-sdk/pull/124) by @Yakuhito; this PR rebases that onto current `main` and updates it to current conventions.
