### PR TITLE
Add Eip712Member CHIP-0043 MIPS member behind chip-0037 feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,6 +802,7 @@ dependencies = [
  "rue-compiler",
  "rue-lir",
  "rue-options",
+ "sha3",
  "thiserror 2.0.17",
 ]
 

--- a/crates/chia-sdk-types/Cargo.toml
+++ b/crates/chia-sdk-types/Cargo.toml
@@ -44,3 +44,4 @@ anyhow = { workspace = true }
 rstest = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
+sha3 = { workspace = true }

--- a/crates/chia-sdk-types/eip712_member.clsp
+++ b/crates/chia-sdk-types/eip712_member.clsp
@@ -1,0 +1,43 @@
+; eip712_member.clsp -- MIPS01 member puzzle for EIP-712-controlled keys.
+;
+; Approves a delegated puzzle when the curried Ethereum-style key has signed
+; the EIP-712 digest of the canonical CHIP-0037 schema:
+;
+;     ChiaCoinSpend(bytes32 coin_id, bytes32 delegated_puzzle_hash)
+;
+; The signed digest is reconstructed inside softfork extension 1 (which
+; activates the keccak256 operator from CHIP-0036). Both the EIP-712
+; reconstruction and the secp256k1_verify call return () on success and raise
+; on failure, so the (all (not ...) (not ...)) gate collapses two successes
+; into a truthy value and any failure aborts the spend before the if runs.
+;
+; CHIP-0037 (EIP-712 wallet support):
+;   https://github.com/Chia-Network/chips/blob/main/CHIPs/chip-0037.md
+; CHIP-0043 (Managed Inner Puzzle Spec / MIPS01):
+;   https://github.com/Chia-Network/chips/blob/main/CHIPs/chip-0043.md
+
+(mod (PREFIX_AND_DOMAIN_SEPARATOR TYPE_HASH PUBKEY    ; curried by Eip712Member
+      Delegated_Puzzle_Hash                            ; truth from M-of-N parent
+      my_id signed_hash signature)                     ; member-specific solution
+
+  ; ASSERT_MY_COIN_ID is condition opcode 73 (per chialisp/condition_codes.clib).
+  ; Inlined to avoid needing a clib include search path at compile time.
+  (defconstant ASSERT_MY_COIN_ID 73)
+
+  (if (all
+        (not (secp256k1_verify PUBKEY signed_hash signature))
+        (not (softfork
+                (q . 2745)  ; pinned softfork cost (matches CHIP-0037 fixture)
+                (q . 1)     ; softfork extension 1 (CHIP-0036 keccak256)
+                (mod
+                  (PREFIX_AND_DOMAIN_SEPARATOR TYPE_HASH my_id
+                   delegated_puzzle_hash signed_hash)
+                  (if (= (keccak256 PREFIX_AND_DOMAIN_SEPARATOR
+                                    (keccak256 TYPE_HASH my_id delegated_puzzle_hash))
+                         signed_hash)
+                      ()
+                      (x)))
+                (list PREFIX_AND_DOMAIN_SEPARATOR TYPE_HASH my_id
+                      Delegated_Puzzle_Hash signed_hash))))
+      (list (list ASSERT_MY_COIN_ID my_id))
+      (x)))

--- a/crates/chia-sdk-types/src/puzzles/mips/members.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/members.rs
@@ -12,6 +12,9 @@ mod r1_member_puzzle_assert;
 mod singleton_member;
 mod singleton_member_with_mode;
 
+#[cfg(feature = "chip-0037")]
+mod eip712_member;
+
 pub use bls_member::*;
 pub use bls_member_puzzle_assert::*;
 pub use bls_taproot_member::*;
@@ -25,3 +28,6 @@ pub use r1_member::*;
 pub use r1_member_puzzle_assert::*;
 pub use singleton_member::*;
 pub use singleton_member_with_mode::*;
+
+#[cfg(feature = "chip-0037")]
+pub use eip712_member::*;

--- a/crates/chia-sdk-types/src/puzzles/mips/members/eip712_member.rs
+++ b/crates/chia-sdk-types/src/puzzles/mips/members/eip712_member.rs
@@ -1,0 +1,265 @@
+use chia_protocol::Bytes32;
+use chia_secp::{K1PublicKey, K1Signature};
+use clvm_traits::{FromClvm, ToClvm};
+
+use crate::{Compilation, compile_chialisp, puzzles::Eip712PrefixAndDomainSeparator};
+
+/// A CHIP-0043 MIPS member puzzle controlled by an Ethereum-style secp256k1
+/// key that signs the canonical CHIP-0037 EIP-712 digest of
+/// `ChiaCoinSpend(bytes32 coin_id, bytes32 delegated_puzzle_hash)`.
+///
+/// Composes with the existing `m_of_n`, `n_of_n`, and `one_of_n` quorum
+/// puzzles, restrictions, and delegated-puzzle wrappers in the same way as
+/// [`K1Member`](super::K1Member) and [`R1Member`](super::R1Member).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[clvm(curry)]
+pub struct Eip712Member {
+    pub prefix_and_domain_separator: Eip712PrefixAndDomainSeparator,
+    pub type_hash: Bytes32,
+    pub public_key: K1PublicKey,
+}
+
+impl Eip712Member {
+    pub fn new(
+        prefix_and_domain_separator: Eip712PrefixAndDomainSeparator,
+        type_hash: Bytes32,
+        public_key: K1PublicKey,
+    ) -> Self {
+        Self {
+            prefix_and_domain_separator,
+            type_hash,
+            public_key,
+        }
+    }
+}
+
+compile_chialisp!(Eip712Member = EIP712_MEMBER, "eip712_member.clsp");
+
+/// Member-specific solution carried by an [`Eip712Member`] spend.
+///
+/// `Delegated_Puzzle_Hash` is supplied by the parent M-of-N layer as a truth
+/// rather than via this struct, matching the convention used by every other
+/// MIPS member type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[clvm(list)]
+pub struct Eip712MemberSolution {
+    pub my_id: Bytes32,
+    pub signed_hash: Bytes32,
+    pub signature: K1Signature,
+}
+
+impl Eip712MemberSolution {
+    pub fn new(my_id: Bytes32, signed_hash: Bytes32, signature: K1Signature) -> Self {
+        Self {
+            my_id,
+            signed_hash,
+            signature,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use chia_secp::K1SecretKey;
+    use clvm_traits::clvm_list;
+    use clvm_utils::CurriedProgram;
+    use clvmr::{Allocator, serde::node_from_bytes, serde::node_to_bytes};
+    use hex_literal::hex;
+    use rand::{Rng, SeedableRng};
+    use rand_chacha::ChaCha8Rng;
+    use rstest::rstest;
+    use sha3::{Digest, Keccak256};
+
+    use crate::{Mod, run_puzzle};
+
+    /// ASSERT_MY_COIN_ID condition opcode (matches the inline value in
+    /// `eip712_member.clsp`).
+    const ASSERT_MY_COIN_ID: u8 = 73;
+
+    /// Compute the canonical CHIP-0037 EIP-712 type hash for
+    /// `ChiaCoinSpend(bytes32 coin_id, bytes32 delegated_puzzle_hash)`.
+    fn type_hash() -> Bytes32 {
+        Bytes32::new(
+            Keccak256::digest(b"ChiaCoinSpend(bytes32 coin_id,bytes32 delegated_puzzle_hash)")
+                .into(),
+        )
+    }
+
+    /// Compute `prefix (0x1901) || domain_separator(genesis_challenge)`.
+    fn prefix_and_domain_separator(genesis_challenge: Bytes32) -> Eip712PrefixAndDomainSeparator {
+        let dom_type_hash =
+            Keccak256::digest(b"EIP712Domain(string name,string version,bytes32 salt)");
+        let mut to_hash = Vec::with_capacity(128);
+        to_hash.extend_from_slice(&dom_type_hash);
+        to_hash.extend_from_slice(&Keccak256::digest(b"Chia Coin Spend"));
+        to_hash.extend_from_slice(&Keccak256::digest(b"1"));
+        to_hash.extend_from_slice(&genesis_challenge);
+        let domain_separator = Keccak256::digest(&to_hash);
+
+        let mut bytes = [0u8; 34];
+        bytes[0] = 0x19;
+        bytes[1] = 0x01;
+        bytes[2..].copy_from_slice(&domain_separator);
+        bytes.into()
+    }
+
+    /// Compute the EIP-712 digest the off-chain wallet must sign:
+    /// `keccak256(prefix_and_domain || keccak256(type_hash || coin_id ||
+    /// delegated_puzzle_hash))`.
+    fn hash_to_sign(
+        prefix_and_domain: &Eip712PrefixAndDomainSeparator,
+        type_hash: Bytes32,
+        coin_id: Bytes32,
+        delegated_puzzle_hash: Bytes32,
+    ) -> Bytes32 {
+        let mut to_hash = Vec::with_capacity(96);
+        to_hash.extend_from_slice(&type_hash);
+        to_hash.extend_from_slice(&coin_id);
+        to_hash.extend_from_slice(&delegated_puzzle_hash);
+        let inner = Keccak256::digest(&to_hash);
+
+        let mut to_hash = Vec::with_capacity(34 + 32);
+        to_hash.extend_from_slice(prefix_and_domain);
+        to_hash.extend_from_slice(&inner);
+        Bytes32::new(Keccak256::digest(&to_hash).into())
+    }
+
+    fn k1_pair(seed: u64) -> (K1SecretKey, K1PublicKey) {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let sk = K1SecretKey::from_bytes(&rng.random()).expect("K1SecretKey::from_bytes");
+        let pk = sk.public_key();
+        (sk, pk)
+    }
+
+    /// Smoke test: forcing `Eip712Member::mod_reveal()` triggers compilation
+    /// of `eip712_member.clsp` via the in-process Chialisp compiler. If the
+    /// source ever stops compiling, this test fails first.
+    #[test]
+    fn test_eip712_member_compiles() {
+        let bytes = Eip712Member::mod_reveal();
+        assert!(
+            !bytes.is_empty(),
+            "compiled Eip712Member bytecode is unexpectedly empty"
+        );
+    }
+
+    /// `mod_hash` must be deterministic across calls (the underlying
+    /// `LazyLock` caches the compilation, so any non-determinism would point
+    /// at a `compile_chialisp` bug rather than at this puzzle).
+    #[test]
+    fn test_eip712_member_mod_hash_is_deterministic() {
+        let a = Eip712Member::mod_hash();
+        let b = Eip712Member::mod_hash();
+        assert_eq!(a, b);
+    }
+
+    /// End-to-end happy path and negative path for the Chialisp logic:
+    ///
+    /// * The curried puzzle, given a valid EIP-712 signature, returns the
+    ///   single-condition list `((ASSERT_MY_COIN_ID my_id))`.
+    /// * Tampering with `signed_hash` causes the softfork-guarded keccak256
+    ///   reconstruction to fail, raising `clvm raise`.
+    /// * Tampering with the signature makes `secp256k1_verify` raise.
+    ///
+    /// Uses mainnet's genesis challenge as the EIP-712 domain salt so the
+    /// fixture stays stable independently of `chia-consensus::TEST_CONSTANTS`.
+    #[rstest]
+    #[case::valid(true, true, true)]
+    #[case::tampered_signed_hash(false, true, false)]
+    #[case::tampered_signature(true, false, false)]
+    fn test_eip712_member_runs(
+        #[case] signed_hash_matches: bool,
+        #[case] signature_matches: bool,
+        #[case] expect_success: bool,
+    ) -> anyhow::Result<()> {
+        let (sk, pk) = k1_pair(0xC0DE_F00D);
+
+        // Mainnet genesis challenge per chia-blockchain initial-config.yaml.
+        let mainnet_genesis = Bytes32::new(hex!(
+            "ccd5bb71183532bff220ba46c268991a3ff07eb358e8255a65c30a2dce0e5fbb"
+        ));
+        let prefix_and_domain = prefix_and_domain_separator(mainnet_genesis);
+        let type_h = type_hash();
+
+        // Pick fixed-seed test fixtures for `coin_id` and the
+        // `delegated_puzzle_hash` the M-of-N parent would supply. They have no
+        // intrinsic meaning here; they are just two distinct 32-byte values
+        // that the puzzle binds the signature to.
+        let mut rng = ChaCha8Rng::seed_from_u64(0x1234_5678);
+        let coin_id_bytes: [u8; 32] = rng.random();
+        let delegated_puzzle_hash_bytes: [u8; 32] = rng.random();
+        let coin_id = Bytes32::new(coin_id_bytes);
+        let delegated_puzzle_hash = Bytes32::new(delegated_puzzle_hash_bytes);
+
+        let real_signed_hash =
+            hash_to_sign(&prefix_and_domain, type_h, coin_id, delegated_puzzle_hash);
+
+        // Always sign the *real* digest. If the test wants to simulate a bad
+        // signature, we tamper with the `K1Signature` bytes after the fact so
+        // `secp256k1_verify` raises; if it wants to simulate the wallet
+        // committing to the wrong digest, we substitute a different
+        // `signed_hash` in the solution so the keccak reconstruction raises.
+        let real_signed_hash_bytes: [u8; 32] = real_signed_hash.into();
+        let real_signature = sk.sign_prehashed(&real_signed_hash_bytes)?;
+
+        let signed_hash_in_solution = if signed_hash_matches {
+            real_signed_hash
+        } else {
+            // A 32-byte value the wallet would never produce for this spend.
+            Bytes32::new([0xAA; 32])
+        };
+
+        let signature_in_solution = if signature_matches {
+            real_signature
+        } else {
+            // Flip a byte to invalidate the ECDSA signature without changing
+            // its length or canonical encoding.
+            let mut tampered = real_signature.to_bytes();
+            tampered[0] ^= 0x01;
+            K1Signature::from_bytes(&tampered).expect("K1Signature::from_bytes")
+        };
+
+        let member = Eip712Member::new(prefix_and_domain, type_h, pk);
+
+        let mut allocator = Allocator::new();
+        let mod_ptr = node_from_bytes(&mut allocator, Eip712Member::mod_reveal().as_ref())?;
+        let curried = CurriedProgram {
+            program: mod_ptr,
+            args: member,
+        }
+        .to_clvm(&mut allocator)?;
+
+        // M-of-N supplies `delegated_puzzle_hash` as a positional arg before
+        // the member's own solution. We mimic that here so the puzzle sees the
+        // same env shape it would see at runtime.
+        let solution = clvm_list!(
+            delegated_puzzle_hash,
+            coin_id,
+            signed_hash_in_solution,
+            signature_in_solution
+        )
+        .to_clvm(&mut allocator)?;
+
+        let result = run_puzzle(&mut allocator, curried, solution);
+
+        if expect_success {
+            let conditions_ptr = result?;
+            let expected =
+                clvm_list!(clvm_list!(ASSERT_MY_COIN_ID, coin_id)).to_clvm(&mut allocator)?;
+            assert_eq!(
+                node_to_bytes(&allocator, conditions_ptr)?,
+                node_to_bytes(&allocator, expected)?,
+                "valid EIP-712 spend should return ((ASSERT_MY_COIN_ID my_id))"
+            );
+        } else {
+            assert!(
+                result.is_err(),
+                "tampered EIP-712 spend should raise but returned conditions"
+            );
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Eip712Member`: a [CHIP-0043 MIPS](https://github.com/Chia-Network/chips/blob/main/CHIPs/chip-0043.md) member puzzle controlled by an Ethereum-style secp256k1 key that signs the canonical [CHIP-0037](https://github.com/Chia-Network/chips/blob/main/CHIPs/chip-0037.md) EIP-712 digest of `ChiaCoinSpend(bytes32 coin_id, bytes32 delegated_puzzle_hash)`.

This member type composes with the existing `m_of_n` / `n_of_n` / `one_of_n` quorum puzzles, restrictions, and the delegated-puzzle wrappers in exactly the same way as `K1Member`, `R1Member`, etc. — so an m-of-n committee of EIP-712-controlled keys (e.g. MetaMask wallets, Ledger / Tangem secp256k1 devices) becomes a one-line composition over the existing MIPS framework, no new quorum puzzle required.

> [!IMPORTANT]
> **Stacked on top of #394.** This branch contains the single new commit on top of `chip-0037-scaffolding`. The diff GitHub shows here will include #394's 738 lines until that PR merges; after a rebase onto `main` the diff will reduce to the 320 lines added by this PR alone. Reviewers can focus on commit `4d9b4679` (`Add Eip712Member CHIP-0043 MIPS member behind chip-0037 feature`).

## What's in the diff (just this commit)

| File | Purpose |
|---|---|
| `crates/chia-sdk-types/eip712_member.clsp` | Chialisp source for the new MIPS member puzzle. Verifies the EIP-712 signature using `secp256k1_verify` (CHIP-0011) and softfork-extension-1 `keccak256` reconstruction (CHIP-0036), then approves the M-of-N parent's delegated puzzle with `(ASSERT_MY_COIN_ID my_id)`. |
| `crates/chia-sdk-types/src/puzzles/mips/members/eip712_member.rs` | `Eip712Member` curry struct (`PREFIX_AND_DOMAIN_SEPARATOR`, `TYPE_HASH`, `K1PublicKey`) + `Eip712MemberSolution` (`my_id`, `signed_hash`, `K1Signature`) + `compile_chialisp!` hookup. Reuses `Eip712PrefixAndDomainSeparator` from the chip-0037 puzzles module so callers don't re-derive the type. |
| `crates/chia-sdk-types/src/puzzles/mips/members.rs` | Register the new module behind `#[cfg(feature = "chip-0037")]`. |
| `crates/chia-sdk-types/Cargo.toml` | Add `sha3` as a **dev-dependency** for off-chain EIP-712 envelope hashing in the e2e tests. No production-dep change. |
| `Cargo.lock` | Lockfile entries for the new dev-dep. |

5 files, +320 / -0.

## Convention compliance

- Curried args use `#[clvm(curry)]`, solution uses `#[clvm(list)]` — matching every other MIPS member.
- Uses `chia_secp::K1PublicKey` / `K1Signature` rather than raw `BytesImpl<33>` / `BytesImpl<64>`, matching `K1Member`, `R1Member`, etc.
- Module wiring mirrors the `chip-0035` / `chip-0037` feature gating already in `mips/members.rs`.
- Chialisp source compiles via the same `compile_chialisp!` pipeline used by `chia-sdk-types`' existing rue/chialisp tests (`compile_chialisp_test.clsp`, `compile_rue_test.rue`).
- No changes outside the `chip-0037` feature; default builds and `chip-0035`-only builds are byte-identical.

## Tests (`cargo test -p chia-sdk-types --features chip-0037`)

```
test puzzles::mips::members::eip712_member::tests::test_eip712_member_compiles ... ok
test puzzles::mips::members::eip712_member::tests::test_eip712_member_mod_hash_is_deterministic ... ok
test puzzles::mips::members::eip712_member::tests::test_eip712_member_runs::case_1_valid ... ok
test puzzles::mips::members::eip712_member::tests::test_eip712_member_runs::case_2_tampered_signed_hash ... ok
test puzzles::mips::members::eip712_member::tests::test_eip712_member_runs::case_3_tampered_signature ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured
```

The end-to-end test runs the curried puzzle through `run_puzzle` with a manually-constructed solution that mimics what M-of-N supplies at runtime (`delegated_puzzle_hash` positional, then the member's own `(my_id signed_hash signature)` solution). It covers:

- **Happy path** (`case_1_valid`): a valid CHIP-0037 EIP-712 signature is accepted; the puzzle returns `((ASSERT_MY_COIN_ID my_id))`.
- **Tampered `signed_hash`** (`case_2_tampered_signed_hash`): the solution carries a digest the wallet would never produce, so the keccak256 reconstruction inside the softfork guard mismatches; the puzzle correctly raises `clvm raise`.
- **Tampered signature** (`case_3_tampered_signature`): a single byte is flipped in the K1Signature so `secp256k1_verify` fails; the puzzle correctly raises `clvm raise`.

The full chia-sdk-driver test suite (1058 tests) also still passes with `--features chip-0037`, so this change has no regressions in any of the existing layer / primitive tests.

## How it composes with the existing MIPS framework

```
                            M-of-N parent (existing m_of_n.clsp / n_of_n.clsp / one_of_n.clsp)
                                                |
              +-----------------+-----------------+-----------------+
              |                 |                                   |
       Eip712Member (1)   Eip712Member (2)    ...           Eip712Member (n)
       curried:           curried:                          curried:
         prefix_and_      prefix_and_                          prefix_and_
         domain_sep         domain_sep                            domain_sep
         type_hash          type_hash                             type_hash
         pubkey_1           pubkey_2                              pubkey_n
```

Each admin's wallet (MetaMask, hardware wallet, custodian API, etc.) signs the EIP-712 typed-data envelope locally and contributes that signature to the spend. The on-chain M-of-N parent picks `m` of those member spends and combines their `(ASSERT_MY_COIN_ID my_id)` outputs with the delegated-puzzle's own conditions, exactly as it does for `K1Member` today.

This means an EIP-712-controlled committee is now a single-line wrapper around `MofNArgs` / `OneOfNArgs` over a list of `Eip712Member`s — no new quorum puzzle, no new restrictions plumbing. It also means EIP-712 keys can be **mixed** with BLS / passkey / r1 keys inside the same quorum.

## How the puzzle works

```clsp
(mod (PREFIX_AND_DOMAIN_SEPARATOR TYPE_HASH PUBKEY    ; curried by Eip712Member
      Delegated_Puzzle_Hash                            ; truth from M-of-N parent
      my_id signed_hash signature)                     ; member-specific solution

  (defconstant ASSERT_MY_COIN_ID 73)

  (if (all
        (not (secp256k1_verify PUBKEY signed_hash signature))
        (not (softfork
                (q . 2745)  ; pinned softfork cost
                (q . 1)     ; softfork extension 1 (CHIP-0036 keccak256)
                (mod
                  (PREFIX_AND_DOMAIN_SEPARATOR TYPE_HASH my_id
                   delegated_puzzle_hash signed_hash)
                  (if (= (keccak256 PREFIX_AND_DOMAIN_SEPARATOR
                                    (keccak256 TYPE_HASH my_id delegated_puzzle_hash))
                         signed_hash)
                      ()
                      (x)))
                (list PREFIX_AND_DOMAIN_SEPARATOR TYPE_HASH my_id
                      Delegated_Puzzle_Hash signed_hash))))
      (list (list ASSERT_MY_COIN_ID my_id))
      (x)))
```

`secp256k1_verify` and `softfork` both return `()` on success and raise on failure, so `(all (not ...) (not ...))` collapses two successes into a truthy value. Any failure aborts before the `if` runs.

## Follow-ups (separate PRs)

- WASM / napi bindings exposing `Eip712Member::curry_tree_hash` and the helpers off-chain wallets need to compute the EIP-712 digest.
- Optional convenience constructor on `MofNArgs` / `OneOfNArgs` that takes a list of `Eip712Member`s directly.

## Provenance

- Original `p2_eip712_message` puzzle bytecode and EIP-712 schema: [Yakuhito's hermes](https://github.com/Yakuhito/hermes) and the canonical CHIP-0037 reference assets.
- Inner softfork sub-puzzle pattern (`(mod ...)` directly inside `softfork` rather than `(q . (mod ...))`): mirrors Yakuhito's `p2_eip712_message.clsp`.
- MIPS member shape (`Mod` impl + curry / list solution + RECEIVE_MESSAGE + `secp256k1_verify` + `ASSERT_MY_COIN_ID`): matches the existing `secp256k1_member.clsp` reference asset.
