### PR TITLE
Add asset flow API

### DIFF
--- a/crates/chia-sdk-driver/src/clear_signing/children.rs
+++ b/crates/chia-sdk-driver/src/clear_signing/children.rs
@@ -1,13 +1,12 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 
 use chia_protocol::{Bytes32, Coin};
-use chia_puzzle_types::offer::{NotarizedPayment, Payment, SettlementPaymentsSolution};
 use chia_puzzles::SETTLEMENT_PAYMENT_HASH;
-use chia_sdk_types::{Condition, puzzles::SettlementPayment};
+use chia_sdk_types::Condition;
 
 use crate::{
-    BURN_PUZZLE_HASH, Cat, CatInfo, DriverError, Facts, Nft, ParsedAsset, ParsedMemos, Puzzle,
-    RevealedCoinSpend, RevealedP2Puzzle, Reveals, SpendContext, calculate_nft_royalty, parse_memos,
+    BURN_PUZZLE_HASH, Cat, DriverError, Facts, Nft, ParsedAsset, ParsedMemos, RevealedCoinSpend,
+    RevealedP2Puzzle, Reveals, SpendContext, parse_memos,
 };
 
 #[derive(Debug, Clone)]
@@ -146,65 +145,6 @@ pub fn parse_children(
                             memos,
                             transfer_type,
                         });
-                    }
-                }
-            }
-            Condition::TransferNft(condition)
-                if let ParsedAsset::Nft(parent_nft) = asset
-                    && parent_nft.info.royalty_basis_points > 0 =>
-            {
-                let cats: HashMap<Bytes32, CatInfo> = reveals
-                    .asset_info()
-                    .cats()
-                    .filter_map(|&asset_id| {
-                        let hidden_puzzle_hash =
-                            reveals.asset_info().cat(asset_id)?.hidden_puzzle_hash;
-                        let cat_info = CatInfo::new(
-                            asset_id,
-                            hidden_puzzle_hash,
-                            SETTLEMENT_PAYMENT_HASH.into(),
-                        );
-                        Some((cat_info.puzzle_hash().into(), cat_info))
-                    })
-                    .collect();
-
-                let hint = ctx.hint(parent_nft.info.royalty_puzzle_hash)?;
-
-                for trade_price in &condition.trade_prices {
-                    let royalty_amount = calculate_nft_royalty(
-                        trade_price.amount,
-                        parent_nft.info.royalty_basis_points,
-                    );
-
-                    let notarized_payment = NotarizedPayment::new(
-                        parent_nft.info.launcher_id,
-                        vec![Payment::new(
-                            parent_nft.info.royalty_puzzle_hash,
-                            royalty_amount,
-                            hint,
-                        )],
-                    );
-
-                    let inner_settlement_solution =
-                        ctx.alloc(&SettlementPaymentsSolution::new(vec![notarized_payment]))?;
-
-                    if trade_price.puzzle_hash == SETTLEMENT_PAYMENT_HASH.into() {
-                        let outer_puzzle = ctx.alloc_mod::<SettlementPayment>()?;
-                        let outer_puzzle = Puzzle::parse(ctx, outer_puzzle);
-                        reveals.reveal_settlement_payment(
-                            ctx,
-                            outer_puzzle,
-                            inner_settlement_solution,
-                        )?;
-                    } else if let Some(cat_info) = cats.get(&trade_price.puzzle_hash) {
-                        let p2_puzzle = ctx.alloc_mod::<SettlementPayment>()?;
-                        let outer_puzzle = cat_info.construct_puzzle(ctx, p2_puzzle)?;
-                        let outer_puzzle = Puzzle::parse(ctx, outer_puzzle);
-                        reveals.reveal_settlement_payment(
-                            ctx,
-                            outer_puzzle,
-                            inner_settlement_solution,
-                        )?;
                     }
                 }
             }

--- a/crates/chia-sdk-driver/src/clear_signing/linked_offer.rs
+++ b/crates/chia-sdk-driver/src/clear_signing/linked_offer.rs
@@ -5,14 +5,14 @@ use chia_sdk_types::Condition;
 use clvmr::Allocator;
 
 use crate::{
-    AssertedRequestedPayment, DriverError, Facts, Reveals, TransferType, VerifiedSpend,
-    parse_asserted_requested_payments,
+    AssertedPayment, DriverError, Facts, Reveals, TransferType, VerifiedSpend,
+    parse_asserted_requested_payments, split_asserted_payments,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LinkedOffer {
     pub reserved_fee: u64,
-    pub requested_payments: Vec<AssertedRequestedPayment>,
+    pub received_payments: Vec<AssertedPayment>,
 }
 
 pub fn build_linked_offer(
@@ -20,10 +20,11 @@ pub fn build_linked_offer(
     allocator: &Allocator,
     spends: &[VerifiedSpend],
     expected_launcher_id: Bytes32,
+    p2_puzzle_hashes: &HashSet<Bytes32>,
 ) -> Result<Option<LinkedOffer>, DriverError> {
     let mut linked_offer = LinkedOffer {
         reserved_fee: 0,
-        requested_payments: vec![],
+        received_payments: vec![],
     };
     let mut has_offer = false;
     let mut found_puzzle_assertions: Option<HashSet<Bytes32>> = None;
@@ -75,8 +76,10 @@ pub fn build_linked_offer(
             offer_facts.assert_puzzle_announcement(announcement_id);
         }
 
-        linked_offer.requested_payments =
+        let asserted_payments =
             parse_asserted_requested_payments(reveals, &offer_facts, allocator)?;
+        linked_offer.received_payments =
+            split_asserted_payments(&asserted_payments, p2_puzzle_hashes).received_payments;
     }
 
     Ok(has_offer.then_some(linked_offer))

--- a/crates/chia-sdk-driver/src/clear_signing/requested_payments.rs
+++ b/crates/chia-sdk-driver/src/clear_signing/requested_payments.rs
@@ -1,5 +1,7 @@
+use std::collections::HashSet;
+
 use chia_protocol::Bytes32;
-use chia_puzzle_types::offer::NotarizedPayment;
+use chia_puzzle_types::offer::{NotarizedPayment, Payment};
 use chia_puzzles::SETTLEMENT_PAYMENT_HASH;
 use chia_sdk_types::{announcement_id, tree_hash_notarized_payment};
 use clvmr::Allocator;
@@ -7,13 +9,26 @@ use clvmr::Allocator;
 use crate::{CatInfo, DriverError, Facts, HashedPtr, NftInfo, Reveals, SingletonInfo};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AssertedRequestedPayment {
-    pub asset: RequestedAsset,
+pub struct AssertedNotarizedPayment {
+    pub asset: ClearSigningAsset,
     pub notarized_payment: NotarizedPayment,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssertedPayment {
+    pub asset: ClearSigningAsset,
+    pub nonce: Bytes32,
+    pub payment: Payment,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SplitAssertedPayments {
+    pub received_payments: Vec<AssertedPayment>,
+    pub external_payments: Vec<AssertedPayment>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RequestedAsset {
+pub enum ClearSigningAsset {
     Xch,
     Cat {
         asset_id: Bytes32,
@@ -28,12 +43,42 @@ pub enum RequestedAsset {
     },
 }
 
+pub fn split_asserted_payments(
+    asserted_payments: &[AssertedNotarizedPayment],
+    p2_puzzle_hashes: &HashSet<Bytes32>,
+) -> SplitAssertedPayments {
+    let mut received_payments = Vec::new();
+    let mut external_payments = Vec::new();
+
+    for asserted_notarized_payment in asserted_payments {
+        for payment in &asserted_notarized_payment.notarized_payment.payments {
+            let asserted_payment = AssertedPayment {
+                asset: asserted_notarized_payment.asset,
+                nonce: asserted_notarized_payment.notarized_payment.nonce,
+                payment: payment.clone(),
+            };
+
+            if p2_puzzle_hashes.contains(&asserted_payment.payment.puzzle_hash) {
+                received_payments.push(asserted_payment);
+            } else {
+                external_payments.push(asserted_payment);
+            }
+        }
+    }
+
+    SplitAssertedPayments {
+        received_payments,
+        external_payments,
+    }
+}
+
 pub fn parse_asserted_requested_payments(
     reveals: &Reveals,
     facts: &Facts,
     allocator: &Allocator,
-) -> Result<Vec<AssertedRequestedPayment>, DriverError> {
+) -> Result<Vec<AssertedNotarizedPayment>, DriverError> {
     let mut payments = Vec::new();
+    let mut seen_announcements = HashSet::new();
 
     let requested_payments = reveals.requested_payments();
     let asset_info = reveals.asset_info();
@@ -42,11 +87,15 @@ pub fn parse_asserted_requested_payments(
         let hash = tree_hash_notarized_payment(allocator, notarized_payment);
         let announcement_id = announcement_id(SETTLEMENT_PAYMENT_HASH.into(), hash);
 
-        if facts.is_puzzle_announcement_asserted(announcement_id) {
-            payments.push(AssertedRequestedPayment {
-                asset: RequestedAsset::Xch,
-                notarized_payment: notarized_payment.clone(),
-            });
+        let payment = AssertedNotarizedPayment {
+            asset: ClearSigningAsset::Xch,
+            notarized_payment: notarized_payment.clone(),
+        };
+
+        if facts.is_puzzle_announcement_asserted(announcement_id)
+            && seen_announcements.insert(announcement_id)
+        {
+            payments.push(payment);
         }
     }
 
@@ -65,14 +114,18 @@ pub fn parse_asserted_requested_payments(
             .puzzle_hash();
             let announcement_id = announcement_id(puzzle_hash.into(), hash);
 
-            if facts.is_puzzle_announcement_asserted(announcement_id) {
-                payments.push(AssertedRequestedPayment {
-                    asset: RequestedAsset::Cat {
-                        asset_id,
-                        hidden_puzzle_hash: info.hidden_puzzle_hash,
-                    },
-                    notarized_payment: notarized_payment.clone(),
-                });
+            let payment = AssertedNotarizedPayment {
+                asset: ClearSigningAsset::Cat {
+                    asset_id,
+                    hidden_puzzle_hash: info.hidden_puzzle_hash,
+                },
+                notarized_payment: notarized_payment.clone(),
+            };
+
+            if facts.is_puzzle_announcement_asserted(announcement_id)
+                && seen_announcements.insert(announcement_id)
+            {
+                payments.push(payment);
             }
         }
     }
@@ -96,17 +149,21 @@ pub fn parse_asserted_requested_payments(
             .puzzle_hash();
             let announcement_id = announcement_id(puzzle_hash.into(), hash);
 
-            if facts.is_puzzle_announcement_asserted(announcement_id) {
-                payments.push(AssertedRequestedPayment {
-                    asset: RequestedAsset::Nft {
-                        launcher_id,
-                        metadata: info.metadata,
-                        metadata_updater_puzzle_hash: info.metadata_updater_puzzle_hash,
-                        royalty_puzzle_hash: info.royalty_puzzle_hash,
-                        royalty_basis_points: info.royalty_basis_points,
-                    },
-                    notarized_payment: notarized_payment.clone(),
-                });
+            let payment = AssertedNotarizedPayment {
+                asset: ClearSigningAsset::Nft {
+                    launcher_id,
+                    metadata: info.metadata,
+                    metadata_updater_puzzle_hash: info.metadata_updater_puzzle_hash,
+                    royalty_puzzle_hash: info.royalty_puzzle_hash,
+                    royalty_basis_points: info.royalty_basis_points,
+                },
+                notarized_payment: notarized_payment.clone(),
+            };
+
+            if facts.is_puzzle_announcement_asserted(announcement_id)
+                && seen_announcements.insert(announcement_id)
+            {
+                payments.push(payment);
             }
         }
     }

--- a/crates/chia-sdk-driver/src/clear_signing/tests.rs
+++ b/crates/chia-sdk-driver/src/clear_signing/tests.rs
@@ -23,12 +23,12 @@ use clvm_utils::{ToTreeHash, tree_hash};
 use rstest::rstest;
 
 use crate::{
-    Action, AssertedRequestedPayment, BURN_PUZZLE_HASH, Bulletin, BulletinMessage, Cat, CatInfo,
-    CatSpend, ClawbackInfo, ClawbackPath, ClawbackV2, CustodyInfo, Deltas, DriverError, DropCoin,
-    FeeAction, HashedPtr, Id, IssuanceKind, LinkedOffer, Nft, OfferPreSplitInfo,
-    P2ConditionsOrSingleton, ParsedAsset, Puzzle, RequestedAsset, Reveals, Spend, SpendContext,
-    SpendKind, Spends, TestP2Puzzle, TestVault, TransferNftById, TransferType, VaultOutput,
-    iter_final_children, parse_vault_transaction,
+    Action, AssetFlow, BURN_PUZZLE_HASH, Bulletin, BulletinMessage, Cat, CatInfo, CatSpend,
+    ClawbackInfo, ClawbackPath, ClawbackV2, ClearSigningAsset, CustodyInfo, Deltas, DriverError,
+    DropCoin, FeeAction, HashedPtr, Id, IssuanceKind, LinkedOffer, Nft, OfferPreSplitInfo,
+    P2ConditionsOrSingleton, ParsedAsset, Puzzle, Reveals, Spend, SpendContext, SpendKind, Spends,
+    TestP2Puzzle, TestVault, TransferNftById, TransferType, VaultOutput, iter_final_children,
+    parse_vault_transaction,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -116,6 +116,10 @@ fn unwrap_nft(asset: &ParsedAsset) -> &Nft {
     nft
 }
 
+fn asset_flow(flows: &[AssetFlow], asset: ClearSigningAsset) -> Option<&AssetFlow> {
+    flows.iter().find(|flow| flow.asset == asset)
+}
+
 #[rstest]
 fn test_clear_signing_vault_child() -> Result<()> {
     let mut sim = Simulator::new();
@@ -175,7 +179,10 @@ fn test_clear_signing_drop_coins() -> Result<()> {
 #[case(20, 0)]
 #[case(20, 10)]
 #[case(20, 20)]
-fn test_clear_signing_reserved_fee(#[case] fee_paid: u64, #[case] reserved_fee: u64) -> Result<()> {
+fn test_clear_signing_reserved_fee(
+    #[case] total_fee: u64,
+    #[case] reserved_fee: u64,
+) -> Result<()> {
     let mut sim = Simulator::new();
     let mut ctx = SpendContext::new();
 
@@ -190,7 +197,7 @@ fn test_clear_signing_reserved_fee(#[case] fee_paid: u64, #[case] reserved_fee: 
                 reserved: true,
             }),
             Action::Fee(FeeAction {
-                amount: fee_paid - reserved_fee,
+                amount: total_fee - reserved_fee,
                 reserved: false,
             }),
         ],
@@ -204,7 +211,12 @@ fn test_clear_signing_reserved_fee(#[case] fee_paid: u64, #[case] reserved_fee: 
         result.delegated_spend,
     )?;
 
-    assert_eq!(tx.fee_paid, fee_paid);
+    assert_eq!(
+        asset_flow(&tx.asset_flows, ClearSigningAsset::Xch)
+            .map(|flow| flow.unaccounted_amount)
+            .unwrap_or(0),
+        total_fee - reserved_fee
+    );
     assert_eq!(tx.reserved_fee, reserved_fee);
 
     Ok(())
@@ -539,7 +551,12 @@ fn test_clear_signing_transfer(
         result.delegated_spend,
     )?;
 
-    assert_eq!(tx.fee_paid, fee);
+    assert_eq!(
+        asset_flow(&tx.asset_flows, ClearSigningAsset::Xch)
+            .map(|flow| flow.unaccounted_amount)
+            .unwrap_or(0),
+        0
+    );
     assert_eq!(tx.reserved_fee, fee);
     assert_eq!(
         tx.spends.len(),
@@ -1263,7 +1280,7 @@ fn test_clear_signing_create_p2_conditions_or_singleton(
         assert_eq!(
             tx.linked_offer,
             Some(LinkedOffer {
-                requested_payments: vec![],
+                received_payments: vec![],
                 reserved_fee: 250,
             })
         );
@@ -1332,12 +1349,10 @@ fn test_clear_signing_spend_p2_conditions_or_singleton_fixed() -> Result<()> {
         result.delegated_spend,
     )?;
 
-    // This is because the intermediate coin used to assert the puzzle announcement has an amount of 1.
-    // It was created by the settlement coin itself, so it's unknown where this coin came from.
-    // Even though it's ephemeral and not technically a fee being paid, it gets counted here conservatively.
-    assert_eq!(tx.fee_paid, 1);
-
-    // We didn't actually pay any fees, so this should be 0.
+    assert_eq!(
+        asset_flow(&tx.asset_flows, ClearSigningAsset::Xch).map(|flow| flow.unaccounted_amount),
+        Some(1)
+    );
     assert_eq!(tx.reserved_fee, 0);
 
     assert_eq!(tx.spends.len(), 1);
@@ -1345,10 +1360,12 @@ fn test_clear_signing_spend_p2_conditions_or_singleton_fixed() -> Result<()> {
     let spend = &tx.spends[0];
     assert_eq!(spend.children.len(), 0);
 
+    assert_eq!(tx.asserted_payments.len(), 1);
     assert_eq!(tx.received_payments.len(), 1);
+    assert_eq!(tx.external_payments.len(), 0);
 
-    let payment = &tx.received_payments[0];
-    assert_eq!(payment.asset, RequestedAsset::Xch);
+    let payment = &tx.asserted_payments[0];
+    assert_eq!(payment.asset, ClearSigningAsset::Xch);
     assert_eq!(payment.notarized_payment.payments.len(), 1);
 
     let payment = &payment.notarized_payment.payments[0];
@@ -1477,7 +1494,7 @@ fn test_clear_signing_offer() -> Result<()> {
         alice.partial_custom_spend(&mut sim, &mut ctx, &actions, spends, Conditions::new())?;
     let coin_spends = [
         result.spend_bundle.coin_spends.clone(),
-        vec![requested_payment],
+        vec![requested_payment.clone(), requested_payment],
     ]
     .concat();
     let reveals = Reveals::from_coin_spends(&mut ctx, &coin_spends)?;
@@ -1497,10 +1514,12 @@ fn test_clear_signing_offer() -> Result<()> {
     assert_eq!(child.asset.coin().amount, 1000);
     assert_eq!(child.memos.p2_puzzle_hash, SETTLEMENT_PAYMENT_HASH.into());
 
+    assert_eq!(tx.asserted_payments.len(), 1);
     assert_eq!(tx.received_payments.len(), 1);
+    assert_eq!(tx.external_payments.len(), 0);
 
-    let payment = &tx.received_payments[0];
-    assert_eq!(payment.asset, RequestedAsset::Xch);
+    let payment = &tx.asserted_payments[0];
+    assert_eq!(payment.asset, ClearSigningAsset::Xch);
     assert_eq!(payment.notarized_payment, notarized_payment);
 
     // Take the offer
@@ -1528,7 +1547,9 @@ fn test_clear_signing_offer() -> Result<()> {
         maker_bundle.aggregated_signature + &result.spend_bundle.aggregated_signature,
     ))?;
 
-    assert_eq!(tx.fee_paid, 1000); // TODO: This isn't ideal
+    let xch_flow = asset_flow(&tx.asset_flows, ClearSigningAsset::Xch).unwrap();
+    assert_eq!(xch_flow.paid_amount, 1000);
+    assert_eq!(xch_flow.unaccounted_amount, 0);
     assert_eq!(tx.reserved_fee, 0);
     assert_eq!(tx.spends.len(), 1);
 
@@ -1539,16 +1560,18 @@ fn test_clear_signing_offer() -> Result<()> {
     assert_eq!(child.asset.coin().amount, 0);
     assert_eq!(child.memos.p2_puzzle_hash, SETTLEMENT_PAYMENT_HASH.into());
 
-    assert_eq!(tx.received_payments.len(), 2);
+    assert_eq!(tx.asserted_payments.len(), 2);
+    assert_eq!(tx.received_payments.len(), 1);
+    assert_eq!(tx.external_payments.len(), 1);
 
-    let xch_payment = &tx.received_payments[0];
-    assert_eq!(xch_payment.asset, RequestedAsset::Xch);
+    let xch_payment = &tx.asserted_payments[0];
+    assert_eq!(xch_payment.asset, ClearSigningAsset::Xch);
     assert_eq!(xch_payment.notarized_payment, notarized_payment);
 
-    let cat_payment = &tx.received_payments[1];
+    let cat_payment = &tx.asserted_payments[1];
     assert_eq!(
         cat_payment.asset,
-        RequestedAsset::Cat {
+        ClearSigningAsset::Cat {
             asset_id: asset_id.unwrap(),
             hidden_puzzle_hash: None,
         }
@@ -1558,6 +1581,9 @@ fn test_clear_signing_offer() -> Result<()> {
     let cat_payment = &cat_payment.notarized_payment.payments[0];
     assert_eq!(cat_payment.puzzle_hash, bob.p2_puzzle_hash);
     assert_eq!(cat_payment.amount, 1000);
+
+    assert_eq!(tx.external_payments[0].payment.amount, 1000);
+    assert_eq!(tx.received_payments[0].payment.amount, 1000);
 
     Ok(())
 }
@@ -1670,25 +1696,13 @@ fn test_clear_signing_nft_offer() -> Result<()> {
     let child = &spend.children[0];
     assert_eq!(child.memos.p2_puzzle_hash, SETTLEMENT_PAYMENT_HASH.into());
 
-    assert_eq!(tx.received_payments.len(), 2);
+    assert_eq!(tx.asserted_payments.len(), 1);
+    assert_eq!(tx.received_payments.len(), 1);
+    assert_eq!(tx.external_payments.len(), 0);
 
-    let xch_payment = &tx.received_payments[0];
-    assert_eq!(xch_payment.asset, RequestedAsset::Xch);
+    let xch_payment = &tx.asserted_payments[0];
+    assert_eq!(xch_payment.asset, ClearSigningAsset::Xch);
     assert_eq!(xch_payment.notarized_payment, notarized_payment);
-
-    let xch_royalty_payment = &tx.received_payments[1];
-    assert_eq!(xch_royalty_payment.asset, RequestedAsset::Xch);
-    assert_eq!(
-        xch_royalty_payment.notarized_payment.nonce,
-        nft.info.launcher_id
-    );
-
-    let xch_royalty_payment = &xch_royalty_payment.notarized_payment.payments[0];
-    assert_eq!(
-        xch_royalty_payment.puzzle_hash,
-        nft.info.royalty_puzzle_hash
-    );
-    assert_eq!(xch_royalty_payment.amount, 30);
 
     // Take the offer
     let settlement_nft = result.outputs.nfts[0];
@@ -1718,7 +1732,9 @@ fn test_clear_signing_nft_offer() -> Result<()> {
         maker_bundle.aggregated_signature + &result.spend_bundle.aggregated_signature,
     ))?;
 
-    assert_eq!(tx.fee_paid, 1030); // TODO: This isn't ideal
+    let xch_flow = asset_flow(&tx.asset_flows, ClearSigningAsset::Xch).unwrap();
+    assert_eq!(xch_flow.paid_amount, 1030);
+    assert_eq!(xch_flow.unaccounted_amount, 0);
     assert_eq!(tx.reserved_fee, 0);
     assert_eq!(tx.spends.len(), 1);
 
@@ -1729,14 +1745,16 @@ fn test_clear_signing_nft_offer() -> Result<()> {
     assert_eq!(child.asset.coin().amount, 0);
     assert_eq!(child.memos.p2_puzzle_hash, SETTLEMENT_PAYMENT_HASH.into());
 
-    assert_eq!(tx.received_payments.len(), 3);
+    assert_eq!(tx.asserted_payments.len(), 3);
+    assert_eq!(tx.received_payments.len(), 1);
+    assert_eq!(tx.external_payments.len(), 2);
 
-    let xch_payment = &tx.received_payments[0];
-    assert_eq!(xch_payment.asset, RequestedAsset::Xch);
+    let xch_payment = &tx.asserted_payments[0];
+    assert_eq!(xch_payment.asset, ClearSigningAsset::Xch);
     assert_eq!(xch_payment.notarized_payment, notarized_payment);
 
-    let xch_royalty_payment = &tx.received_payments[1];
-    assert_eq!(xch_royalty_payment.asset, RequestedAsset::Xch);
+    let xch_royalty_payment = &tx.asserted_payments[1];
+    assert_eq!(xch_royalty_payment.asset, ClearSigningAsset::Xch);
     assert_eq!(
         xch_royalty_payment.notarized_payment.nonce,
         nft.info.launcher_id
@@ -1749,10 +1767,10 @@ fn test_clear_signing_nft_offer() -> Result<()> {
     );
     assert_eq!(xch_royalty_payment.amount, 30);
 
-    let nft_payment = &tx.received_payments[2];
+    let nft_payment = &tx.asserted_payments[2];
     assert_eq!(
         nft_payment.asset,
-        RequestedAsset::Nft {
+        ClearSigningAsset::Nft {
             launcher_id: nft.info.launcher_id,
             metadata: nft.info.metadata,
             metadata_updater_puzzle_hash: nft.info.metadata_updater_puzzle_hash,
@@ -1765,6 +1783,10 @@ fn test_clear_signing_nft_offer() -> Result<()> {
     let nft_payment = &nft_payment.notarized_payment.payments[0];
     assert_eq!(nft_payment.puzzle_hash, bob.p2_puzzle_hash);
     assert_eq!(nft_payment.amount, 1);
+
+    assert_eq!(tx.external_payments[0].payment.amount, 1000);
+    assert_eq!(tx.external_payments[1].payment.amount, 30);
+    assert_eq!(tx.received_payments[0].payment.amount, 1);
 
     Ok(())
 }
@@ -1808,7 +1830,9 @@ fn test_clear_signing_single_sided_offer() -> Result<()> {
     assert_eq!(child.asset.coin().amount, 1000);
     assert_eq!(child.memos.p2_puzzle_hash, SETTLEMENT_PAYMENT_HASH.into());
 
+    assert_eq!(tx.asserted_payments.len(), 0);
     assert_eq!(tx.received_payments.len(), 0);
+    assert_eq!(tx.external_payments.len(), 0);
 
     // Take the offer
     let settlement_cat = result.outputs.cats[0][0];
@@ -1835,19 +1859,28 @@ fn test_clear_signing_single_sided_offer() -> Result<()> {
         maker_bundle.aggregated_signature + &result.spend_bundle.aggregated_signature,
     ))?;
 
-    assert_eq!(tx.fee_paid, 1); // TODO: This isn't ideal
+    let cat_asset = ClearSigningAsset::Cat {
+        asset_id: asset_id.unwrap(),
+        hidden_puzzle_hash: None,
+    };
+    assert_eq!(
+        asset_flow(&tx.asset_flows, cat_asset).map(|flow| flow.unaccounted_amount),
+        Some(1)
+    );
     assert_eq!(tx.reserved_fee, 0);
     assert_eq!(tx.spends.len(), 1);
 
     let spend = &tx.spends[0];
     assert_eq!(spend.children.len(), 0);
 
+    assert_eq!(tx.asserted_payments.len(), 1);
     assert_eq!(tx.received_payments.len(), 1);
+    assert_eq!(tx.external_payments.len(), 0);
 
-    let cat_payment = &tx.received_payments[0];
+    let cat_payment = &tx.asserted_payments[0];
     assert_eq!(
         cat_payment.asset,
-        RequestedAsset::Cat {
+        ClearSigningAsset::Cat {
             asset_id: asset_id.unwrap(),
             hidden_puzzle_hash: None,
         }
@@ -1939,17 +1972,27 @@ fn test_clear_signing_pre_split_offer() -> Result<()> {
     assert_eq!(child.asset.coin().amount, 250);
     assert_eq!(child.memos.p2_puzzle_hash, alice.p2_puzzle_hash);
 
+    assert_eq!(tx.asserted_payments.len(), 0);
     assert_eq!(tx.received_payments.len(), 0);
+    assert_eq!(tx.external_payments.len(), 0);
 
+    assert_eq!(tx.linked_offer.as_ref().unwrap().reserved_fee, 0);
+    assert_eq!(tx.linked_offer.as_ref().unwrap().received_payments.len(), 1);
     assert_eq!(
-        tx.linked_offer,
-        Some(LinkedOffer {
-            requested_payments: vec![AssertedRequestedPayment {
-                asset: RequestedAsset::Xch,
-                notarized_payment: notarized_payment.clone(),
-            }],
-            reserved_fee: 0,
-        })
+        tx.linked_offer.as_ref().unwrap().received_payments[0].asset,
+        ClearSigningAsset::Xch
+    );
+    assert_eq!(
+        tx.linked_offer.as_ref().unwrap().received_payments[0]
+            .payment
+            .amount,
+        1000
+    );
+    assert_eq!(
+        tx.linked_offer.as_ref().unwrap().received_payments[0]
+            .payment
+            .puzzle_hash,
+        alice.p2_puzzle_hash
     );
 
     // Take the offer
@@ -1977,7 +2020,9 @@ fn test_clear_signing_pre_split_offer() -> Result<()> {
         result.delegated_spend,
     )?;
 
-    assert_eq!(tx.fee_paid, 1000); // TODO: This isn't ideal
+    let xch_flow = asset_flow(&tx.asset_flows, ClearSigningAsset::Xch).unwrap();
+    assert_eq!(xch_flow.paid_amount, 1000);
+    assert_eq!(xch_flow.unaccounted_amount, 0);
     assert_eq!(tx.reserved_fee, 0);
     assert_eq!(tx.spends.len(), 1);
 
@@ -1988,16 +2033,18 @@ fn test_clear_signing_pre_split_offer() -> Result<()> {
     assert_eq!(child.asset.coin().amount, 0);
     assert_eq!(child.memos.p2_puzzle_hash, SETTLEMENT_PAYMENT_HASH.into());
 
-    assert_eq!(tx.received_payments.len(), 2);
+    assert_eq!(tx.asserted_payments.len(), 2);
+    assert_eq!(tx.received_payments.len(), 1);
+    assert_eq!(tx.external_payments.len(), 1);
 
-    let xch_payment = &tx.received_payments[0];
-    assert_eq!(xch_payment.asset, RequestedAsset::Xch);
+    let xch_payment = &tx.asserted_payments[0];
+    assert_eq!(xch_payment.asset, ClearSigningAsset::Xch);
     assert_eq!(xch_payment.notarized_payment, notarized_payment);
 
-    let cat_payment = &tx.received_payments[1];
+    let cat_payment = &tx.asserted_payments[1];
     assert_eq!(
         cat_payment.asset,
-        RequestedAsset::Cat {
+        ClearSigningAsset::Cat {
             asset_id: asset_id.unwrap(),
             hidden_puzzle_hash: None,
         }
@@ -2007,6 +2054,9 @@ fn test_clear_signing_pre_split_offer() -> Result<()> {
     let cat_payment = &cat_payment.notarized_payment.payments[0];
     assert_eq!(cat_payment.puzzle_hash, bob.p2_puzzle_hash);
     assert_eq!(cat_payment.amount, 750);
+
+    assert_eq!(tx.external_payments[0].payment.amount, 1000);
+    assert_eq!(tx.received_payments[0].payment.amount, 750);
 
     Ok(())
 }

--- a/crates/chia-sdk-driver/src/clear_signing/vault_transaction.rs
+++ b/crates/chia-sdk-driver/src/clear_signing/vault_transaction.rs
@@ -9,12 +9,12 @@ use clvmr::NodePtr;
 use indexmap::{IndexMap, IndexSet};
 
 use crate::{
-    AssertedRequestedPayment, ClawbackInfo, CustodyInfo, DriverError, DropCoin, Facts, Issuance,
-    IssuanceKind, LinkedOffer, P2ConditionsOrSingletonInfo, P2SingletonInfo, ParsedAsset,
-    ParsedChild, ParsedSpend, RevealedCoinSpend, Reveals, Spend, SpendContext, VaultMessage,
-    VaultOutput, build_linked_offer, get_extra_delta_message, mips_puzzle_hash,
-    parse_asserted_requested_payments, parse_children, parse_run_cat_tail, parse_spend,
-    parse_vault_delegated_spend,
+    AssertedNotarizedPayment, AssertedPayment, ClawbackInfo, ClearSigningAsset, CustodyInfo,
+    DriverError, DropCoin, Facts, Issuance, IssuanceKind, LinkedOffer, P2ConditionsOrSingletonInfo,
+    P2SingletonInfo, ParsedAsset, ParsedChild, ParsedSpend, RevealedCoinSpend, Reveals, Spend,
+    SpendContext, VaultMessage, VaultOutput, build_linked_offer, get_extra_delta_message,
+    mips_puzzle_hash, parse_asserted_requested_payments, parse_children, parse_run_cat_tail,
+    parse_spend, parse_vault_delegated_spend, split_asserted_payments,
 };
 
 /// The purpose of this is to provide sufficient information to verify what is happening to a vault and its assets
@@ -35,27 +35,37 @@ pub struct VaultTransaction {
     /// records the coin id of the spend that emitted the `RunCatTail` condition, so callers can
     /// match it back to the corresponding `VerifiedSpend` by coin id if they want to.
     pub issuances: Vec<Issuance>,
-    /// Requested payments which were both revealed and asserted by the vault spend. These are assets which are going
-    /// to be received when and if the transaction is confirmed on-chain.
-    pub received_payments: Vec<AssertedRequestedPayment>,
+    /// Settlement payments which were both revealed and asserted by the transaction.
+    pub asserted_payments: Vec<AssertedNotarizedPayment>,
+    /// Individual asserted payment outputs whose puzzle hash matches one of the vault's known p2 puzzle hashes.
+    pub received_payments: Vec<AssertedPayment>,
+    /// Individual asserted payment outputs whose puzzle hash doesn't match one of the vault's known p2 puzzle hashes.
+    /// These are not necessarily paid by the vault, but the transaction requires them to happen.
+    pub external_payments: Vec<AssertedPayment>,
+    /// Per-asset value flow for verified spends and asserted payments.
+    pub asset_flows: Vec<AssetFlow>,
     /// If this transaction creates one or more offer pre-split coins, this rolls them up into a
     /// description of the future offer. Per-leg details (the individual pre-split amounts) live
     /// in the children's transfer type field.
     ///
     /// [`None`] means the transaction does not link any offer pre-split coins.
     pub linked_offer: Option<LinkedOffer>,
-    /// Total fees (different between input and output amounts) paid by coin spends authorized by the vault.
-    /// If the transaction is signed, the fee is guaranteed to be at least this amount, unless it's not reserved.
-    /// The reason to include unreserved fees is to make it clear that the XCH is leaving the vault due to this transaction.
-    pub fee_paid: u64,
     /// The amount of fees reserved by coin spends authorized by the vault.
-    /// If this is greater than or equal to the fee paid, you can be sure that the XCH spent for fees will not be
-    /// maliciously redirected for some other purpose by the submitter of the transaction after signing.
     pub reserved_fee: u64,
     /// The known p2 puzzle hashes of the vault, based on revealed nonces (the first address is included by default).
     pub p2_puzzle_hashes: Vec<Bytes32>,
     /// The delegated puzzle hash that is being signed for.
     pub delegated_puzzle_hash: Bytes32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AssetFlow {
+    pub asset: ClearSigningAsset,
+    pub input_amount: u64,
+    pub output_amount: u64,
+    pub received_amount: u64,
+    pub paid_amount: u64,
+    pub unaccounted_amount: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -190,23 +200,18 @@ pub fn parse_vault_transaction(
 
     let delegated_puzzle_hash = tree_hash(ctx, delegated_spend.puzzle).into();
 
-    let reserved_fee = facts.reserved_fees().try_into()?;
-
-    let mut input_amount = 0;
-    let mut output_amount = 0;
-
-    for spend in &verified_spends {
-        input_amount += u128::from(spend.asset.coin().amount);
-
-        for child in &spend.children {
-            output_amount += u128::from(child.asset.coin().amount);
-        }
-    }
-
-    let fee_paid = input_amount.saturating_sub(output_amount).try_into()?;
-    let received_payments = parse_asserted_requested_payments(&reveals, &facts, ctx)?;
     let p2_puzzle_hashes = calculate_p2_puzzle_hashes(&reveals, launcher_id);
-    let linked_offer = build_linked_offer(&reveals, ctx, &verified_spends, launcher_id)?;
+    let p2_puzzle_hash_set = p2_puzzle_hashes.iter().copied().collect();
+    let reserved_fee = facts.reserved_fees().try_into()?;
+    let asserted_payments = parse_asserted_requested_payments(&reveals, &facts, ctx)?;
+    let split_payments = split_asserted_payments(&asserted_payments, &p2_puzzle_hash_set);
+    let linked_offer = build_linked_offer(
+        &reveals,
+        ctx,
+        &verified_spends,
+        launcher_id,
+        &p2_puzzle_hash_set,
+    )?;
 
     // Hydrate ephemerally spent bulletin children.
     let mut bulletins = HashMap::new();
@@ -227,14 +232,23 @@ pub fn parse_vault_transaction(
         }
     }
 
+    let asset_flows = build_asset_flows(
+        &verified_spends,
+        &split_payments.received_payments,
+        &split_payments.external_payments,
+        reserved_fee,
+    );
+
     Ok(VaultTransaction {
         vault_child: vault_spend.child,
         drop_coins: vault_spend.drop_coins,
         spends: verified_spends,
         issuances,
-        received_payments,
+        asserted_payments,
+        received_payments: split_payments.received_payments,
+        external_payments: split_payments.external_payments,
+        asset_flows,
         linked_offer,
-        fee_paid,
         reserved_fee,
         p2_puzzle_hashes,
         delegated_puzzle_hash,
@@ -352,6 +366,131 @@ fn verify_spend(
         custody,
         children,
     }))
+}
+
+#[derive(Debug, Clone)]
+struct AssetFlowTotals {
+    asset: ClearSigningAsset,
+    input_amount: u64,
+    output_amount: u64,
+    received_amount: u64,
+    paid_amount: u64,
+}
+
+fn build_asset_flows(
+    spends: &[VerifiedSpend],
+    received_payments: &[AssertedPayment],
+    external_payments: &[AssertedPayment],
+    reserved_fee: u64,
+) -> Vec<AssetFlow> {
+    let spend_coin_ids: HashSet<Bytes32> = spends
+        .iter()
+        .map(|spend| spend.asset.coin().coin_id())
+        .collect();
+    let child_coin_ids: HashSet<Bytes32> = spends
+        .iter()
+        .flat_map(|spend| spend.children.iter())
+        .map(|child| child.asset.coin().coin_id())
+        .collect();
+
+    let mut flows = IndexMap::<Option<Bytes32>, AssetFlowTotals>::new();
+
+    for spend in spends {
+        if !child_coin_ids.contains(&spend.asset.coin().coin_id()) {
+            asset_flow_mut(&mut flows, asset_from_parsed(&spend.asset)).input_amount +=
+                spend.asset.coin().amount;
+        }
+
+        for child in &spend.children {
+            if !spend_coin_ids.contains(&child.asset.coin().coin_id()) {
+                asset_flow_mut(&mut flows, asset_from_parsed(&child.asset)).output_amount +=
+                    child.asset.coin().amount;
+            }
+        }
+    }
+
+    for asserted_payment in received_payments {
+        asset_flow_mut(&mut flows, asserted_payment.asset).received_amount +=
+            asserted_payment.payment.amount;
+    }
+
+    for asserted_payment in external_payments {
+        asset_flow_mut(&mut flows, asserted_payment.asset).paid_amount +=
+            asserted_payment.payment.amount;
+    }
+
+    flows
+        .into_values()
+        .filter_map(|flow| {
+            let unaccounted_amount = flow
+                .input_amount
+                .saturating_sub(flow.output_amount)
+                .saturating_sub(flow.paid_amount)
+                .saturating_sub(if matches!(flow.asset, ClearSigningAsset::Xch) {
+                    reserved_fee
+                } else {
+                    0
+                });
+
+            let include = flow.input_amount > 0
+                || flow.output_amount > 0
+                || flow.received_amount > 0
+                || flow.paid_amount > 0;
+
+            include.then_some((flow, unaccounted_amount))
+        })
+        .map(|(flow, unaccounted_amount)| AssetFlow {
+            asset: flow.asset,
+            input_amount: flow.input_amount,
+            output_amount: flow.output_amount,
+            received_amount: flow.received_amount,
+            paid_amount: flow.paid_amount,
+            unaccounted_amount,
+        })
+        .collect()
+}
+
+fn asset_flow_mut(
+    flows: &mut IndexMap<Option<Bytes32>, AssetFlowTotals>,
+    asset: ClearSigningAsset,
+) -> &mut AssetFlowTotals {
+    flows
+        .entry(asset_flow_key(asset))
+        .or_insert_with(|| AssetFlowTotals {
+            asset,
+            input_amount: 0,
+            output_amount: 0,
+            received_amount: 0,
+            paid_amount: 0,
+        })
+}
+
+fn asset_flow_key(asset: ClearSigningAsset) -> Option<Bytes32> {
+    match asset {
+        ClearSigningAsset::Xch => None,
+        ClearSigningAsset::Cat { asset_id, .. }
+        | ClearSigningAsset::Nft {
+            launcher_id: asset_id,
+            ..
+        } => Some(asset_id),
+    }
+}
+
+fn asset_from_parsed(asset: &ParsedAsset) -> ClearSigningAsset {
+    match asset {
+        ParsedAsset::Xch(_) | ParsedAsset::Bulletin(_) => ClearSigningAsset::Xch,
+        ParsedAsset::Cat(cat) => ClearSigningAsset::Cat {
+            asset_id: cat.info.asset_id,
+            hidden_puzzle_hash: cat.info.hidden_puzzle_hash,
+        },
+        ParsedAsset::Nft(nft) => ClearSigningAsset::Nft {
+            launcher_id: nft.info.launcher_id,
+            metadata: nft.info.metadata,
+            metadata_updater_puzzle_hash: nft.info.metadata_updater_puzzle_hash,
+            royalty_puzzle_hash: nft.info.royalty_puzzle_hash,
+            royalty_basis_points: nft.info.royalty_basis_points,
+        },
+    }
 }
 
 fn calculate_p2_puzzle_hashes(reveals: &Reveals, launcher_id: Bytes32) -> Vec<Bytes32> {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the public shape of vault transaction summaries used for signing review (removed fee_paid, new payment splits and flows), though behavior stays conservative and is covered by extensive clear-signing tests.
> 
> **Overview**
> Refactors **clear-signing** `VaultTransaction` reporting so reviewers see per-asset balances and clearer offer/settlement legs instead of a single global `fee_paid`.
> 
> **`VaultTransaction`** drops `fee_paid` and adds `asset_flows` (`AssetFlow` per `ClearSigningAsset`: inputs, outputs, received, paid, and `unaccounted_amount` after reserved XCH fees). Settlement data is split into `asserted_payments` (full notarized), `received_payments` (legs to known vault p2 hashes), and `external_payments` (required legs to other addresses). `RequestedAsset` / `AssertedRequestedPayment` are renamed to `ClearSigningAsset` / `AssertedNotarizedPayment`, with per-leg `AssertedPayment` via `split_asserted_payments`. Duplicate puzzle-announcement matches are deduped when parsing asserted payments.
> 
> **Offers:** `LinkedOffer` now exposes `received_payments` as filtered `AssertedPayment` values (not full notarized bundles), using vault p2 hashes in `build_linked_offer`. NFT `TransferNft` handling no longer synthesizes royalty settlement reveals in `parse_children`.
> 
> Tests are updated for the new fields and offer/NFT/fee scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7334cb2e711c51c7a64367d349f676fdfa3c3302. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->