### PR TITLE
Bump version to 0.34.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "bindy"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "bip39",
  "chia-bls 0.36.1",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "bindy-macro"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "chia-sdk-bindings",
  "convert_case",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "chia-sdk-bindings"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "bindy",
  "bip39",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "chia-sdk-cli"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "chia-wallet-sdk",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "chia-sdk-client"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "aws-lc-rs",
  "chia-protocol",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "chia-sdk-coinset"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "chia-protocol",
  "chia-traits 0.36.1",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "chia-sdk-daemon"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "chia-sdk-client",
  "chia-sdk-coinset",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "chia-sdk-derive"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "convert_case",
  "quote",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "chia-sdk-driver"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "chia-sdk-signer"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "chia-bls 0.36.1",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "chia-sdk-test"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "chia-sdk-types"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "chia-bls 0.36.1",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "chia-sdk-utils"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "bech32",
  "chia-protocol",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "chia-wallet-sdk"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "chia-bls 0.36.1",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "chia-wallet-sdk-py"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "bindy",
  "bindy-macro",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "chia-wallet-sdk-wasm"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "bindy",
  "bindy-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-wallet-sdk"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "An unofficial SDK for building Chia wallets."
@@ -107,19 +107,19 @@ anyhow = { workspace = true }
 hex-literal = { workspace = true }
 
 [workspace.dependencies]
-chia-wallet-sdk = { version = "0.33.0", path = "." }
-chia-sdk-client = { version = "0.33.0", path = "./crates/chia-sdk-client" }
-chia-sdk-driver = { version = "0.33.0", path = "./crates/chia-sdk-driver" }
-chia-sdk-signer = { version = "0.33.0", path = "./crates/chia-sdk-signer" }
-chia-sdk-test = { version = "0.33.0", path = "./crates/chia-sdk-test" }
-chia-sdk-types = { version = "0.33.0", path = "./crates/chia-sdk-types" }
-chia-sdk-derive = { version = "0.33.0", path = "./crates/chia-sdk-types/derive" }
-chia-sdk-utils = { version = "0.33.0", path = "./crates/chia-sdk-utils" }
-chia-sdk-coinset = { version = "0.33.0", path = "./crates/chia-sdk-coinset" }
-chia-sdk-daemon = { version = "0.33.0", path = "./crates/chia-sdk-daemon" }
-chia-sdk-bindings = { version = "0.33.0", path = "./crates/chia-sdk-bindings" }
-bindy = { version = "0.33.0", path = "./crates/chia-sdk-bindings/bindy" }
-bindy-macro = { version = "0.33.0", path = "./crates/chia-sdk-bindings/bindy-macro" }
+chia-wallet-sdk = { version = "0.34.0", path = "." }
+chia-sdk-client = { version = "0.34.0", path = "./crates/chia-sdk-client" }
+chia-sdk-driver = { version = "0.34.0", path = "./crates/chia-sdk-driver" }
+chia-sdk-signer = { version = "0.34.0", path = "./crates/chia-sdk-signer" }
+chia-sdk-test = { version = "0.34.0", path = "./crates/chia-sdk-test" }
+chia-sdk-types = { version = "0.34.0", path = "./crates/chia-sdk-types" }
+chia-sdk-derive = { version = "0.34.0", path = "./crates/chia-sdk-types/derive" }
+chia-sdk-utils = { version = "0.34.0", path = "./crates/chia-sdk-utils" }
+chia-sdk-coinset = { version = "0.34.0", path = "./crates/chia-sdk-coinset" }
+chia-sdk-daemon = { version = "0.34.0", path = "./crates/chia-sdk-daemon" }
+chia-sdk-bindings = { version = "0.34.0", path = "./crates/chia-sdk-bindings" }
+bindy = { version = "0.34.0", path = "./crates/chia-sdk-bindings/bindy" }
+bindy-macro = { version = "0.34.0", path = "./crates/chia-sdk-bindings/bindy-macro" }
 chia-ssl = "0.42.1"
 chia-protocol = "0.36.1"
 chia-consensus = "0.36.1"

--- a/crates/chia-sdk-bindings/Cargo.toml
+++ b/crates/chia-sdk-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-sdk-bindings"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Underlying implementation of chia-wallet-sdk bindings."

--- a/crates/chia-sdk-bindings/bindy-macro/Cargo.toml
+++ b/crates/chia-sdk-bindings/bindy-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bindy-macro"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Macro for the Bindy generator."

--- a/crates/chia-sdk-bindings/bindy/Cargo.toml
+++ b/crates/chia-sdk-bindings/bindy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bindy"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Generator for chia-wallet-sdk bindings."

--- a/crates/chia-sdk-cli/Cargo.toml
+++ b/crates/chia-sdk-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-sdk-cli"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Command line tools powered by the Chia Wallet SDK."

--- a/crates/chia-sdk-client/Cargo.toml
+++ b/crates/chia-sdk-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-sdk-client"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Utilities for connecting to Chia full node peers via the light wallet protocol."

--- a/crates/chia-sdk-coinset/Cargo.toml
+++ b/crates/chia-sdk-coinset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-sdk-coinset"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Utilities for connecting to Chia full node peers via the light wallet protocol."

--- a/crates/chia-sdk-daemon/Cargo.toml
+++ b/crates/chia-sdk-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-sdk-daemon"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Chia daemon websocket client with RPC support via ChiaRpcClient trait."

--- a/crates/chia-sdk-daemon/README.md
+++ b/crates/chia-sdk-daemon/README.md
@@ -8,9 +8,9 @@ Add the crate with one of the TLS features enabled:
 
 ```toml
 [dependencies]
-chia-sdk-daemon = { version = "0.33.0", features = ["native-tls"] }
+chia-sdk-daemon = { version = "0.34.0", features = ["native-tls"] }
 # or
-chia-sdk-daemon = { version = "0.33.0", features = ["rustls"] }
+chia-sdk-daemon = { version = "0.34.0", features = ["rustls"] }
 ```
 
 ## Connecting to the Daemon

--- a/crates/chia-sdk-driver/Cargo.toml
+++ b/crates/chia-sdk-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-sdk-driver"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Driver code for interacting with standard puzzles on the Chia blockchain."

--- a/crates/chia-sdk-signer/Cargo.toml
+++ b/crates/chia-sdk-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-sdk-signer"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Calculates the signatures required for coin spends in a transaction."

--- a/crates/chia-sdk-test/Cargo.toml
+++ b/crates/chia-sdk-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-sdk-test"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "A wallet simulator and related tooling for testing Chia wallet code."

--- a/crates/chia-sdk-types/Cargo.toml
+++ b/crates/chia-sdk-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-sdk-types"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Standard Chia types for things such as puzzle info and conditions."

--- a/crates/chia-sdk-types/derive/Cargo.toml
+++ b/crates/chia-sdk-types/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-sdk-derive"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Derive macros for chia-sdk-types."

--- a/crates/chia-sdk-utils/Cargo.toml
+++ b/crates/chia-sdk-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-sdk-utils"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "General utilities for the chia-wallet-sdk."

--- a/napi/npm/darwin-arm64/package.json
+++ b/napi/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chia-wallet-sdk-darwin-arm64",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/xch-dev/chia-wallet-sdk"

--- a/napi/npm/darwin-universal/package.json
+++ b/napi/npm/darwin-universal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chia-wallet-sdk-darwin-universal",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/xch-dev/chia-wallet-sdk"

--- a/napi/npm/darwin-x64/package.json
+++ b/napi/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chia-wallet-sdk-darwin-x64",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/xch-dev/chia-wallet-sdk"

--- a/napi/npm/linux-arm64-gnu/package.json
+++ b/napi/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chia-wallet-sdk-linux-arm64-gnu",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/xch-dev/chia-wallet-sdk"

--- a/napi/npm/linux-x64-gnu/package.json
+++ b/napi/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chia-wallet-sdk-linux-x64-gnu",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/xch-dev/chia-wallet-sdk"

--- a/napi/npm/win32-x64-msvc/package.json
+++ b/napi/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chia-wallet-sdk-win32-x64-msvc",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/xch-dev/chia-wallet-sdk"

--- a/napi/package.json
+++ b/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chia-wallet-sdk",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/pyo3/Cargo.toml
+++ b/pyo3/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "chia-wallet-sdk-py"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2024"
 
 [lib]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "chia-wallet-sdk-wasm"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "WASM bindings for the Chia Wallet SDK."


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Release-metadata-only version bump with no runtime or behavioral code changes.
> 
> **Overview**
> Bumps the monorepo from **0.33.0** to **0.34.0** so Rust crates, bindings, and published packages stay aligned for the next release.
> 
> **`Cargo.toml`** updates the root `chia-wallet-sdk` version and every `[workspace.dependencies]` entry (`chia-sdk-*`, `bindy`, `bindy-macro`). Each workspace crate’s `Cargo.toml`, **`Cargo.lock`**, **`pyo3`**, **`wasm`**, the main **`napi/package.json`**, and all platform-specific **`napi/npm/*`** packages get the same version. **`crates/chia-sdk-daemon/README.md`** dependency examples now cite `0.34.0`.
> 
> There are no API, logic, or dependency changes beyond the version strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b9b50d0c69816a47bfe09af589805717a70a626. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->