### PR TITLE
Bump Rue to 0.8.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2096,6 +2096,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3342,9 +3361,9 @@ dependencies = [
 
 [[package]]
 name = "rue-ast"
-version = "0.6.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8feffcdd1f81db8d83980714cdd15d53608f7cc49e4d4a1c52d0fe1d523c4b"
+checksum = "82e99e24bfbaa8fe116b23d3fa1df09e2f59982e654e04430f8fad0d348271fa"
 dependencies = [
  "paste",
  "rue-parser",
@@ -3352,13 +3371,14 @@ dependencies = [
 
 [[package]]
 name = "rue-compiler"
-version = "0.6.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b58c388afe6e7fb78e63f43b455c57b6f788f1e2b65ae895e9ff38039ab2fdc"
+checksum = "59f127828ed5bdd04dee995b5028f3ae291394850e66856bb6998198c51c4514"
 dependencies = [
  "clvmr",
  "hex",
  "id-arena",
+ "include_dir",
  "indexmap",
  "log",
  "num-bigint",
@@ -3377,19 +3397,18 @@ dependencies = [
 
 [[package]]
 name = "rue-diagnostic"
-version = "0.6.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cccb3041f21c77e80ea8fdb03e7214b91195d939f3146f054e27020ea1a9"
+checksum = "d25461b6850121106735e1abe334ecf2bf56e27244284d46ef5dfbc0e4bc2894"
 dependencies = [
- "derive_more",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "rue-hir"
-version = "0.6.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d73674bfcd164e453dbeabfa99cb952827abf7bc0540ed5bf6d2ccea97d06a"
+checksum = "cd0cc66defc213a291efd185f0ff18f703abec2850c931a459ce187ee667e1fd"
 dependencies = [
  "derive_more",
  "hex",
@@ -3405,15 +3424,15 @@ dependencies = [
 
 [[package]]
 name = "rue-lexer"
-version = "0.6.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68345f23ba80d548d4a671de14e455de74ae58fccfa436db105b35308a1780ed"
+checksum = "579df9994fcc6485832d6a19f77309f38d12cf48bb73b7a2b99eb4ae094aaadf"
 
 [[package]]
 name = "rue-lir"
-version = "0.6.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099f3c3d6b432bb94cf8876b7f71b650d6887ae9193e8063c529feca37276b6f"
+checksum = "c3ba00e6908f8baf1de08b41f11213a1bc0ef4dfd75f47ebca341665b1d1f5b7"
 dependencies = [
  "chialisp",
  "clvm-traits 0.28.1",
@@ -3429,9 +3448,9 @@ dependencies = [
 
 [[package]]
 name = "rue-options"
-version = "0.6.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f94c541b1397b7fbc4aaba36440c0bc11ddb703b024a424dd2fe193ec413b7"
+checksum = "a6c9855c49ee3f3f248004bfb2daf166ca0648a46820f95255fedb4e815b269d"
 dependencies = [
  "serde",
  "thiserror 2.0.17",
@@ -3440,9 +3459,9 @@ dependencies = [
 
 [[package]]
 name = "rue-parser"
-version = "0.6.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d23577d98f535c02d2898e0a0e9cdf04b82d1ea91b15cd31e66141bce73c4c5"
+checksum = "2eeffa2e32037202a8fb8a4361f06bf01dd0a7d7ace092dfab3ff1aa5f2cd42f"
 dependencies = [
  "derive_more",
  "indexmap",
@@ -3456,9 +3475,9 @@ dependencies = [
 
 [[package]]
 name = "rue-types"
-version = "0.6.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6dc5f584d1ff7cf562737aa990d746def396ca4211c8f56c2d28d6dc00718b"
+checksum = "0766e7089d3b5e41cebb17bee53055479adee1925207e4c1a5dea36a2bf29d06"
 dependencies = [
  "clvmr",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,9 +188,9 @@ console_error_panic_hook = "0.1.7"
 prettytable-rs = "0.10.0"
 clap = "4.5.50"
 bincode = "2.0.1"
-rue-compiler = "0.6.0"
-rue-options = "0.6.0"
-rue-lir = "0.6.0"
+rue-compiler = "0.8.5"
+rue-options = "0.8.5"
+rue-lir = "0.8.5"
 colored = "3.1.1"
 
 [profile.release]

--- a/crates/chia-sdk-types/src/load_clvm.rs
+++ b/crates/chia-sdk-types/src/load_clvm.rs
@@ -105,6 +105,15 @@ pub fn compile_rue(
     let mut ctx = Compiler::new(project.options);
 
     let tree = FileTree::compile_path(&mut ctx, &project.entrypoint, &mut HashMap::new())?;
+    let base_path = if project.entrypoint.is_file() {
+        project
+            .entrypoint
+            .parent()
+            .ok_or(LoadClvmError::InvalidFileName)?
+            .canonicalize()?
+    } else {
+        project.entrypoint.canonicalize()?
+    };
 
     let ptr = if let Some(export_name) = export_name {
         if let Some(export) = tree
@@ -113,6 +122,7 @@ pub fn compile_rue(
                 &mut allocator,
                 main_kind.as_ref(),
                 Some(export_name),
+                &base_path,
             )?
             .into_iter()
             .next()
@@ -122,10 +132,12 @@ pub fn compile_rue(
             return Err(LoadClvmError::ExportNotFound(export_name.to_string()));
         }
     } else if let Some(main_kind) = main_kind
-        && let Some(main) = tree.main(&mut ctx, &mut allocator, &main_kind)?
+        && let Some(main) = tree.main(&mut ctx, &mut allocator, &main_kind, base_path.clone())?
     {
         main
-    } else if let Some(main) = tree.main(&mut ctx, &mut allocator, &normalize_path(&path)?)? {
+    } else if let Some(main) =
+        tree.main(&mut ctx, &mut allocator, &normalize_path(&path)?, base_path)?
+    {
         main
     } else {
         return Err(LoadClvmError::MainNotFound);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches puzzle compilation for Rue projects; incorrect base_path could change which main/export is compiled, though the change is a straightforward API adaptation.
> 
> **Overview**
> Upgrades **Rue** from `0.6.0` to **`0.8.5`** across `rue-compiler`, `rue-options`, and `rue-lir` (workspace `Cargo.toml` and lockfile), pulling in **`include_dir`** via the compiler crate.
> 
> **`compile_rue`** in `load_clvm.rs` is updated for the new Rue API: it derives a canonical **`base_path`** from the project entrypoint (parent directory when the entrypoint is a file, otherwise the entrypoint directory) and passes that into **`FileTree::exports`** and **`tree.main`** so export/main resolution matches Rue 0.8.5’s path semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6249c3ce6cc43b6bbd1c5026d236c814d9f6d6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->