### PR TITLE
Add overflow handling for oracle fee

### DIFF
--- a/crates/chia-sdk-driver/src/primitives/datalayer/datastore_info.rs
+++ b/crates/chia-sdk-driver/src/primitives/datalayer/datastore_info.rs
@@ -298,7 +298,6 @@ pub fn get_merkle_tree(
     Ok(MerkleTree::new(&leaves))
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/chia-sdk-driver/src/primitives/datalayer/datastore_info.rs
+++ b/crates/chia-sdk-driver/src/primitives/datalayer/datastore_info.rs
@@ -77,8 +77,8 @@ impl DelegatedPuzzle {
 
                 // puzzle hash bech32m_decode(oracle_address), not puzzle hash of the whole oracle puzze!
                 let oracle_fee: u64 = BigInt::from_signed_bytes_be(&remaining_memos.remove(0))
-                    .to_u64_digits()
-                    .1[0];
+                    .try_into()
+                    .map_err(|_| DriverError::InvalidMemo)?;
 
                 Ok(DelegatedPuzzle::Oracle(puzzle_hash.into(), oracle_fee))
             }
@@ -296,4 +296,34 @@ pub fn get_merkle_tree(
     }
 
     Ok(MerkleTree::new(&leaves))
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chia_protocol::Bytes;
+
+    fn oracle_memos(fee_bytes: Vec<u8>) -> Vec<Bytes> {
+        vec![
+            Bytes::new(vec![HintType::OraclePuzzle as u8]),
+            Bytes::new(vec![0x11; 32]),
+            Bytes::new(fee_bytes),
+        ]
+    }
+
+    #[test]
+    fn oracle_fee_from_memos_accepts_zero() {
+        let mut memos = oracle_memos(vec![0x00]);
+        let puzzle = DelegatedPuzzle::from_memos(&mut memos).unwrap();
+        assert_eq!(puzzle, DelegatedPuzzle::Oracle([0x11; 32].into(), 0));
+    }
+
+    #[test]
+    fn oracle_fee_from_memos_rejects_overflow() {
+        // 2^64 does not fit in u64
+        let mut memos = oracle_memos(vec![0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+        let err = DelegatedPuzzle::from_memos(&mut memos).unwrap_err();
+        assert!(matches!(err, DriverError::InvalidMemo));
+    }
 }

--- a/crates/chia-sdk-driver/src/primitives/datalayer/datastore_info.rs
+++ b/crates/chia-sdk-driver/src/primitives/datalayer/datastore_info.rs
@@ -297,32 +297,3 @@ pub fn get_merkle_tree(
 
     Ok(MerkleTree::new(&leaves))
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use chia_protocol::Bytes;
-
-    fn oracle_memos(fee_bytes: Vec<u8>) -> Vec<Bytes> {
-        vec![
-            Bytes::new(vec![HintType::OraclePuzzle as u8]),
-            Bytes::new(vec![0x11; 32]),
-            Bytes::new(fee_bytes),
-        ]
-    }
-
-    #[test]
-    fn oracle_fee_from_memos_accepts_zero() {
-        let mut memos = oracle_memos(vec![0x00]);
-        let puzzle = DelegatedPuzzle::from_memos(&mut memos).unwrap();
-        assert_eq!(puzzle, DelegatedPuzzle::Oracle([0x11; 32].into(), 0));
-    }
-
-    #[test]
-    fn oracle_fee_from_memos_rejects_overflow() {
-        // 2^64 does not fit in u64
-        let mut memos = oracle_memos(vec![0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
-        let err = DelegatedPuzzle::from_memos(&mut memos).unwrap_err();
-        assert!(matches!(err, DriverError::InvalidMemo));
-    }
-}


### PR DESCRIPTION
## Summary
- Parse DataStore oracle fee memos with `BigInt::try_into()` instead of indexing `to_u64_digits().1`
- Reject values that do not fit in `u64` as `InvalidMemo`


Made with [Cursor](https://cursor.com)