### PR TITLE
Consolidate running of metadata updater and check hash

### DIFF
--- a/crates/chia-sdk-driver/src/action_system/singleton_spends.rs
+++ b/crates/chia-sdk-driver/src/action_system/singleton_spends.rs
@@ -4,16 +4,13 @@ use chia_protocol::{Bytes32, Coin};
 use chia_puzzles::{SETTLEMENT_PAYMENT_HASH, SINGLETON_LAUNCHER_HASH};
 use chia_sdk_types::{
     Conditions,
-    conditions::{
-        AssertPuzzleAnnouncement, CreateCoin, NewMetadataOutput, TransferNft, UpdateNftMetadata,
-    },
+    conditions::{AssertPuzzleAnnouncement, CreateCoin, TransferNft, UpdateNftMetadata},
 };
-use clvm_traits::clvm_list;
 use clvmr::NodePtr;
 
 use crate::{
     Asset, Did, DidInfo, DriverError, FungibleSpend, HashedPtr, Launcher, Nft, NftInfo,
-    OptionContract, OutputSet, SingletonInfo, Spend, SpendContext, SpendKind,
+    OptionContract, OutputSet, SingletonInfo, Spend, SpendContext, SpendKind, run_metadata_updater,
 };
 
 #[derive(Debug, Clone)]
@@ -418,16 +415,16 @@ impl SingletonAsset for Nft {
         if let Some(spend) = metadata_update_spend {
             conditions.push(UpdateNftMetadata::new(spend.puzzle, spend.solution));
 
-            let metadata_updater_solution = ctx.alloc(&clvm_list!(
-                singleton.asset.info.metadata,
+            let metadata_info = run_metadata_updater(
+                ctx,
+                &singleton.asset.info.metadata,
                 singleton.asset.info.metadata_updater_puzzle_hash,
-                spend.solution
-            ))?;
-            let ptr = ctx.run(spend.puzzle, metadata_updater_solution)?;
-            let output = ctx.extract::<NewMetadataOutput<HashedPtr, NodePtr>>(ptr)?;
+                spend.puzzle,
+                spend.solution,
+            )?;
 
-            nft_info.metadata = output.metadata_info.new_metadata;
-            nft_info.metadata_updater_puzzle_hash = output.metadata_info.new_updater_puzzle_hash;
+            nft_info.metadata = metadata_info.new_metadata;
+            nft_info.metadata_updater_puzzle_hash = metadata_info.new_updater_puzzle_hash;
         }
 
         if let Some(transfer_condition) = transfer_condition {

--- a/crates/chia-sdk-driver/src/driver_error.rs
+++ b/crates/chia-sdk-driver/src/driver_error.rs
@@ -28,6 +28,9 @@ pub enum DriverError {
     #[error("invalid mod hash")]
     InvalidModHash,
 
+    #[error("metadata updater puzzle hash mismatch")]
+    MetadataUpdaterPuzzleHashMismatch,
+
     #[error("non-standard inner puzzle layer")]
     NonStandardLayer,
 

--- a/crates/chia-sdk-driver/src/layers/nft_state_layer.rs
+++ b/crates/chia-sdk-driver/src/layers/nft_state_layer.rs
@@ -1,10 +1,6 @@
 use chia_protocol::Bytes32;
 use chia_puzzle_types::nft::{NftStateLayerArgs, NftStateLayerSolution};
 use chia_puzzles::NFT_STATE_LAYER_HASH;
-use chia_sdk_types::{
-    conditions::{NewMetadataOutput, UpdateNftMetadata},
-    run_puzzle,
-};
 use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::{CurriedProgram, ToTreeHash, TreeHash};
 use clvmr::{Allocator, NodePtr};
@@ -127,34 +123,5 @@ where
             },
         }
         .tree_hash()
-    }
-}
-
-impl<M, I> NftStateLayer<M, I> {
-    pub fn get_next_metadata(
-        allocator: &mut Allocator,
-        current_metadata: &M,
-        curent_metadata_updater_puzzle_hash: Bytes32,
-        condition: UpdateNftMetadata<NodePtr, NodePtr>,
-    ) -> Result<M, DriverError>
-    where
-        M: ToClvm<Allocator> + FromClvm<Allocator>,
-    {
-        let real_metadata_updater_solution: Vec<NodePtr> = vec![
-            current_metadata.to_clvm(allocator)?,
-            curent_metadata_updater_puzzle_hash.to_clvm(allocator)?,
-            condition.updater_solution,
-        ];
-        let real_metadata_updater_solution = real_metadata_updater_solution.to_clvm(allocator)?;
-
-        let output = run_puzzle(
-            allocator,
-            condition.updater_puzzle_reveal,
-            real_metadata_updater_solution,
-        )?;
-
-        let parsed = NewMetadataOutput::<M, NodePtr>::from_clvm(allocator, output)?;
-
-        Ok(parsed.metadata_info.new_metadata)
     }
 }

--- a/crates/chia-sdk-driver/src/primitives/datalayer/datastore.rs
+++ b/crates/chia-sdk-driver/src/primitives/datalayer/datastore.rs
@@ -19,7 +19,10 @@ use clvm_utils::{CurriedProgram, ToTreeHash, TreeHash, tree_hash};
 use clvmr::{Allocator, NodePtr};
 use num_bigint::BigInt;
 
-use crate::{DriverError, Layer, NftStateLayer, Puzzle, SingletonLayer, Spend, SpendContext};
+use crate::{
+    DriverError, Layer, NftStateLayer, Puzzle, SingletonLayer, Spend, SpendContext,
+    run_metadata_updater,
+};
 
 use super::{
     DataStoreInfo, DataStoreMetadata, DelegatedPuzzle, HintType, MetadataWithRootHash,
@@ -343,12 +346,14 @@ where
 
         let new_metadata = if let Some(inner_new_metadata_condition) = inner_new_metadata_condition
         {
-            NftStateLayer::<M, NodePtr>::get_next_metadata(
+            run_metadata_updater(
                 allocator,
                 &state_layer.metadata,
                 state_layer.metadata_updater_puzzle_hash,
-                inner_new_metadata_condition,
+                inner_new_metadata_condition.updater_puzzle_reveal,
+                inner_new_metadata_condition.updater_solution,
             )?
+            .new_metadata
         } else {
             state_layer.metadata
         };

--- a/crates/chia-sdk-driver/src/primitives/nft.rs
+++ b/crates/chia-sdk-driver/src/primitives/nft.rs
@@ -481,6 +481,21 @@ mod tests {
             uri: "another.com".to_string(),
         }
         .spend(ctx)?;
+
+        let mismatched_updater = ctx.alloc(&())?;
+        let error = run_metadata_updater(
+            ctx,
+            &nft.info.metadata,
+            nft.info.metadata_updater_puzzle_hash,
+            mismatched_updater,
+            metadata_update.solution,
+        )
+        .expect_err("metadata updater puzzle hash should not match");
+        assert!(matches!(
+            error,
+            DriverError::MetadataUpdaterPuzzleHashMismatch
+        ));
+
         let parent_nft = nft;
         let nft = nft.transfer_with_metadata(
             ctx,

--- a/crates/chia-sdk-driver/src/primitives/nft/metadata_update.rs
+++ b/crates/chia-sdk-driver/src/primitives/nft/metadata_update.rs
@@ -1,4 +1,12 @@
-use chia_sdk_types::puzzles::NftMetadataUpdater;
+use chia_protocol::Bytes32;
+use chia_sdk_types::{
+    conditions::{NewMetadataInfo, NewMetadataOutput},
+    puzzles::NftMetadataUpdater,
+    run_puzzle,
+};
+use clvm_traits::{FromClvm, ToClvm};
+use clvm_utils::tree_hash;
+use clvmr::{Allocator, NodePtr};
 
 use crate::{DriverError, Spend, SpendContext};
 
@@ -24,4 +32,29 @@ impl MetadataUpdate {
         })?;
         Ok(Spend::new(ctx.alloc_mod::<NftMetadataUpdater>()?, solution))
     }
+}
+
+pub fn run_metadata_updater<M>(
+    allocator: &mut Allocator,
+    current_metadata: &M,
+    current_metadata_updater_puzzle_hash: Bytes32,
+    updater_puzzle_reveal: NodePtr,
+    updater_solution: NodePtr,
+) -> Result<NewMetadataInfo<M>, DriverError>
+where
+    M: ToClvm<Allocator> + FromClvm<Allocator>,
+{
+    if tree_hash(allocator, updater_puzzle_reveal) != current_metadata_updater_puzzle_hash.into() {
+        return Err(DriverError::MetadataUpdaterPuzzleHashMismatch);
+    }
+
+    let metadata_updater_solution: Vec<NodePtr> = vec![
+        current_metadata.to_clvm(allocator)?,
+        current_metadata_updater_puzzle_hash.to_clvm(allocator)?,
+        updater_solution,
+    ];
+    let metadata_updater_solution = metadata_updater_solution.to_clvm(allocator)?;
+
+    let output = run_puzzle(allocator, updater_puzzle_reveal, metadata_updater_solution)?;
+    Ok(NewMetadataOutput::<M, NodePtr>::from_clvm(allocator, output)?.metadata_info)
 }

--- a/crates/chia-sdk-driver/src/primitives/nft/nft_info.rs
+++ b/crates/chia-sdk-driver/src/primitives/nft/nft_info.rs
@@ -2,7 +2,7 @@ use chia_protocol::Bytes32;
 use chia_puzzle_types::nft::{NftOwnershipLayerArgs, NftStateLayerArgs};
 use chia_puzzles::NFT_STATE_LAYER_HASH;
 use chia_sdk_types::{Condition, Mod, conditions::CreateCoin, run_puzzle};
-use clvm_traits::{FromClvm, ToClvm};
+use clvm_traits::FromClvm;
 use clvm_utils::{ToTreeHash, TreeHash};
 use clvmr::{Allocator, NodePtr};
 
@@ -236,6 +236,7 @@ mod tests {
     use chia_puzzle_types::nft::NftMetadata;
     use chia_sdk_test::Simulator;
     use chia_sdk_types::{Conditions, conditions::TransferNft};
+    use clvm_traits::ToClvm;
 
     use crate::{
         IntermediateLauncher, Launcher, NftMint, SingletonInfo, SpendContext, StandardLayer,

--- a/crates/chia-sdk-driver/src/primitives/nft/nft_info.rs
+++ b/crates/chia-sdk-driver/src/primitives/nft/nft_info.rs
@@ -1,18 +1,14 @@
 use chia_protocol::Bytes32;
 use chia_puzzle_types::nft::{NftOwnershipLayerArgs, NftStateLayerArgs};
 use chia_puzzles::NFT_STATE_LAYER_HASH;
-use chia_sdk_types::{
-    Condition, Mod,
-    conditions::{CreateCoin, NewMetadataOutput},
-    run_puzzle,
-};
-use clvm_traits::{FromClvm, ToClvm, clvm_list};
+use chia_sdk_types::{Condition, Mod, conditions::CreateCoin, run_puzzle};
+use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::{ToTreeHash, TreeHash};
 use clvmr::{Allocator, NodePtr};
 
 use crate::{
     DriverError, HashedPtr, Layer, NftOwnershipLayer, NftStateLayer, Puzzle, RoyaltyTransferLayer,
-    SingletonInfo, SingletonLayer, Spend,
+    SingletonInfo, SingletonLayer, Spend, run_metadata_updater,
 };
 
 pub type StandardNftLayers<M, I> =
@@ -193,23 +189,15 @@ impl NftInfo {
         }
 
         if let Some(new_metadata) = new_metadata {
-            let metadata_updater_solution = clvm_list!(
+            let metadata_info = run_metadata_updater(
+                allocator,
                 &self.metadata,
                 self.metadata_updater_puzzle_hash,
-                new_metadata.updater_solution
-            )
-            .to_clvm(allocator)?;
-
-            let output = run_puzzle(
-                allocator,
                 new_metadata.updater_puzzle_reveal,
-                metadata_updater_solution,
+                new_metadata.updater_solution,
             )?;
-
-            let output = NewMetadataOutput::<HashedPtr, NodePtr>::from_clvm(allocator, output)?
-                .metadata_info;
-            info.metadata = output.new_metadata;
-            info.metadata_updater_puzzle_hash = output.new_updater_puzzle_hash;
+            info.metadata = metadata_info.new_metadata;
+            info.metadata_updater_puzzle_hash = metadata_info.new_updater_puzzle_hash;
         }
 
         info.p2_puzzle_hash = create_coin.puzzle_hash;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how NFT and DataStore metadata transitions are simulated off-chain; wrong-hash reveals now fail where they might have been accepted before, which is stricter but could affect edge-case parsing if callers passed mismatched reveals.
> 
> **Overview**
> Metadata updater CLVM execution is centralized in **`run_metadata_updater`**, and callers no longer duplicate solution building and `run_puzzle` parsing.
> 
> Before running the updater, the helper **compares the revealed updater puzzle’s tree hash to the NFT/DataStore’s stored `metadata_updater_puzzle_hash`**, returning **`DriverError::MetadataUpdaterPuzzleHashMismatch`** when they differ. **`NftStateLayer::get_next_metadata`** is removed; **`NftInfo::child_from_p2_spend`**, singleton NFT spends, and DataStore child parsing now go through the shared helper. A test asserts the mismatch error path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ebf5cc045237d024c5a097f0d73e2e0eacd93b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->