### PR TITLE
Add overflow handling for offer fee accumulation

### DIFF
--- a/crates/chia-sdk-driver/src/driver_error.rs
+++ b/crates/chia-sdk-driver/src/driver_error.rs
@@ -52,6 +52,9 @@ pub enum DriverError {
     #[error("expected even oracle fee, but it was odd")]
     OddOracleFee,
 
+    #[error("fee overflow")]
+    FeeOverflow,
+
     #[error("custom driver error: {0}")]
     Custom(String),
 

--- a/crates/chia-sdk-driver/src/offers/offer_coins.rs
+++ b/crates/chia-sdk-driver/src/offers/offer_coins.rs
@@ -131,7 +131,10 @@ impl OfferCoins {
             }
         }
 
-        self.fee += other.fee;
+        self.fee = self
+            .fee
+            .checked_add(other.fee)
+            .ok_or(DriverError::FeeOverflow)?;
 
         Ok(())
     }
@@ -194,7 +197,10 @@ impl OfferCoins {
 
         for condition in conditions {
             if let Some(reserve_fee) = condition.as_reserve_fee() {
-                self.fee += reserve_fee.amount;
+                self.fee = self
+                    .fee
+                    .checked_add(reserve_fee.amount)
+                    .ok_or(DriverError::FeeOverflow)?;
             }
 
             let Some(create_coin) = condition.into_create_coin() else {
@@ -237,5 +243,23 @@ impl AddAsset for OfferCoins {
         for option in self.options.into_values() {
             spends.add(option);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_offer_coins_fee_overflow_on_extend() {
+        let mut coins = OfferCoins {
+            fee: u64::MAX,
+            ..OfferCoins::default()
+        };
+        let other = OfferCoins {
+            fee: 1,
+            ..OfferCoins::default()
+        };
+        assert!(matches!(coins.extend(other), Err(DriverError::FeeOverflow)));
     }
 }

--- a/crates/chia-sdk-driver/src/offers/offer_coins.rs
+++ b/crates/chia-sdk-driver/src/offers/offer_coins.rs
@@ -245,21 +245,3 @@ impl AddAsset for OfferCoins {
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_offer_coins_fee_overflow_on_extend() {
-        let mut coins = OfferCoins {
-            fee: u64::MAX,
-            ..OfferCoins::default()
-        };
-        let other = OfferCoins {
-            fee: 1,
-            ..OfferCoins::default()
-        };
-        assert!(matches!(coins.extend(other), Err(DriverError::FeeOverflow)));
-    }
-}


### PR DESCRIPTION
## Summary
- Accumulate `OfferCoins::fee` with `checked_add` in `parse` and `extend`
- Return `DriverError::FeeOverflow` instead of wrapping in release builds

## Test plan
- [ ] Existing offer tests still pass in CI